### PR TITLE
Reinstate -DSYS_OPENSSL

### DIFF
--- a/ledger-core-cosmos/CMakeLists.txt
+++ b/ledger-core-cosmos/CMakeLists.txt
@@ -40,6 +40,9 @@ endif()
 # Ledger-core dependency
 set(ledger-core_DIR "/usr/lib/ledger-core/cmake" CACHE PATH "Installation directory of ledger-core")
 
+if (SYS_OPENSSL)
+  find_package(OpenSSL REQUIRED)
+endif()
 add_subdirectory(src)
 
 string(FIND "${CMAKE_OSX_SYSROOT}" "iphone" IS_IOS)

--- a/ledger-core/CMakeLists.txt
+++ b/ledger-core/CMakeLists.txt
@@ -39,6 +39,11 @@ endif()
 
 enable_testing()
 
+if (SYS_OPENSSL)
+    # Here instead of in lib/CMakeLists to get all variables in this scope.
+    # set(... PARENT_SCOPE) for find_package to find.
+    find_package(OpenSSL REQUIRED)
+endif()
 add_subdirectory(lib)
 add_subdirectory(src)
 
@@ -74,6 +79,24 @@ install(
     DESTINATION ${ledger-core-pkg-location}
 )
 
+if (SYS_OPENSSL)
+  install( TARGETS blake
+    EXPORT ledger-core
+    ARCHIVE       DESTINATION lib/ledger-core
+    LIBRARY       DESTINATION lib/ledger-core
+    FRAMEWORK     DESTINATION lib/ledger-core )
+else()
+  install(
+    TARGETS
+    crypto
+    ssl
+    EXPORT ledger-core
+    ARCHIVE       DESTINATION lib/ledger-core
+    LIBRARY       DESTINATION lib/ledger-core
+    FRAMEWORK     DESTINATION lib/ledger-core
+    )
+endif()
+
 install(
     TARGETS
         ledger-core
@@ -82,7 +105,6 @@ install(
         ledger-core-interface
         bigd
         fmt
-        crypto
         soci_sqlite3
         soci_core_static
         leveldb
@@ -93,7 +115,6 @@ install(
         ledger-qt-host
         ledger-core-integration-test
         mongoose
-        ssl
         gtest gtest_main
     EXPORT ledger-core
     ARCHIVE       DESTINATION lib/ledger-core

--- a/ledger-core/lib/CMakeLists.txt
+++ b/ledger-core/lib/CMakeLists.txt
@@ -9,7 +9,22 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/leveldb")
 include(ProjectSecp256k1)
 add_subdirectory(bigd)
 add_subdirectory(fmt)
-add_subdirectory(openssl)
+if (SYS_OPENSSL)
+  add_definitions(-DBLAKE256 -DBLAKE244)
+  add_library( blake
+    openssl/crypto/blake/blake256.c
+    openssl/crypto/blake/blake2b.c
+    openssl/crypto/blake/blake256.h
+    openssl/crypto/blake/blake2b.h
+    )
+  target_include_directories(
+    blake PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
+    $<INSTALL_INTERFACE:include>
+    )
+else()
+  add_subdirectory(openssl)
+endif()
 add_subdirectory(ethash)
 add_subdirectory(snappy)
 add_subdirectory(leveldb)

--- a/ledger-core/lib/sqlcipher/CMakeLists.txt
+++ b/ledger-core/lib/sqlcipher/CMakeLists.txt
@@ -3,7 +3,12 @@ project(sqlcipher)
 add_library(sqlcipher STATIC sqlite3.c sqlite3.h sqlite3ext.h)
 
 target_link_libraries(sqlcipher PUBLIC ${CMAKE_DL_LIBS})
-target_link_libraries(sqlcipher PUBLIC crypto)
+if (SYS_OPENSSL)
+    target_link_libraries(sqlcipher PUBLIC OpenSSL::Crypto)
+    target_include_directories(sqlcipher PUBLIC ${OPENSSL_INCLUDE_DIR})
+else()
+    target_link_libraries(sqlcipher PUBLIC crypto)
+endif()
 target_include_directories(
     sqlcipher PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>

--- a/ledger-core/src/CMakeLists.txt
+++ b/ledger-core/src/CMakeLists.txt
@@ -112,7 +112,13 @@ else()
     target_link_libraries(ledger-core-interface INTERFACE fmt)
 endif(MINGW OR MSVC)
 
-target_link_libraries(ledger-core-interface INTERFACE crypto)
+if (SYS_OPENSSL)
+    target_link_libraries(ledger-core-interface INTERFACE OpenSSL::Crypto)
+    target_link_libraries(ledger-core-interface INTERFACE OpenSSL::SSL)
+    target_link_libraries(ledger-core-interface INTERFACE blake)
+else()
+    target_link_libraries(ledger-core-interface INTERFACE crypto)
+endif()
 target_link_libraries(ledger-core-interface INTERFACE soci_sqlite3)
 target_link_libraries(ledger-core-interface INTERFACE soci_core_static)
 target_link_libraries(ledger-core-interface INTERFACE leveldb)
@@ -132,6 +138,18 @@ target_link_libraries(ledger-core-interface INTERFACE ethash)
 
 target_link_libraries(ledger-core-interface INTERFACE ${SQLITE_LIB})
 
+if (SYS_OPENSSL)
+  target_include_directories(ledger-core-interface INTERFACE
+    ${OPENSSL_INCLUDE_DIR}
+    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/lib/openssl/crypto/blake> $<INSTALL_INTERFACE:include/ledger-core/lib/openssl/crypto/blake>
+    )
+else()
+    target_include_directories(ledger-core-interface INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/lib/openssl/include>      $<INSTALL_INTERFACE:include/ledger-core/lib/openssl/include>
+    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/lib/openssl/crypto/blake> $<INSTALL_INTERFACE:include/ledger-core/lib/openssl/crypto/blake>
+    )
+endif()
+
 target_include_directories(
     ledger-core-interface INTERFACE
     $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/inc>                      $<INSTALL_INTERFACE:include/ledger-core>
@@ -139,8 +157,6 @@ target_include_directories(
     $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/lib/rapidjson/include>    $<INSTALL_INTERFACE:include/ledger-core/lib/rapidjson/include>
     $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/lib/soci/core>            $<INSTALL_INTERFACE:include/ledger-core/lib/soci/core>
     $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/lib/soci_sqlite3>         $<INSTALL_INTERFACE:include/ledger-core/lib/soci_sqlite3>
-    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/lib/openssl/include>      $<INSTALL_INTERFACE:include/ledger-core/lib/openssl/include>
-    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/lib/openssl/crypto/blake> $<INSTALL_INTERFACE:include/ledger-core/lib/openssl/crypto/blake>
     $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/lib/leveldb/include>      $<INSTALL_INTERFACE:include/ledger-core/lib/leveldb/include>
     $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/lib/boost>                $<INSTALL_INTERFACE:include/ledger-core/lib/boost>
     $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/lib/cereal>               $<INSTALL_INTERFACE:include/ledger-core/lib/cereal>

--- a/ledger-core/src/core/crypto/HMAC.cpp
+++ b/ledger-core/src/core/crypto/HMAC.cpp
@@ -38,12 +38,21 @@ std::vector<uint8_t> ledger::core::HMAC::sha256(const std::vector<uint8_t>& key,
                                                     const std::vector<uint8_t>& data) {
     auto len = SHA256_DIGEST_LENGTH;
     std::vector<uint8_t> hash(len);
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     HMAC_CTX hmac;
     HMAC_CTX_init(&hmac);
     HMAC_Init_ex(&hmac, key.data(), key.size(), EVP_sha256(), NULL);
     HMAC_Update(&hmac, data.data(), data.size());
     HMAC_Final(&hmac, hash.data(), (unsigned int *)(&len));
     HMAC_cleanup(&hmac);
+#else
+    HMAC_CTX * hmac = HMAC_CTX_new();
+    HMAC_CTX_reset(hmac);
+    HMAC_Init_ex(hmac, key.data(), key.size(), EVP_sha256(), NULL);
+    HMAC_Update(hmac, data.data(), data.size());
+    HMAC_Final(hmac, hash.data(), (unsigned int *)(&len));
+    HMAC_CTX_free(hmac);
+#endif
     return hash;
 }
 
@@ -51,11 +60,20 @@ std::vector<uint8_t> ledger::core::HMAC::sha512(const std::vector<uint8_t>& key,
                                                     const std::vector<uint8_t>& data) {
     auto len = SHA512_DIGEST_LENGTH;
     std::vector<uint8_t> hash(len);
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     HMAC_CTX hmac;
     HMAC_CTX_init(&hmac);
     HMAC_Init_ex(&hmac, key.data(), key.size(), EVP_sha512(), NULL);
     HMAC_Update(&hmac, data.data(), data.size());
     HMAC_Final(&hmac, hash.data(), (unsigned int *)(&len));
     HMAC_cleanup(&hmac);
+#else
+    HMAC_CTX * hmac = HMAC_CTX_new();
+    HMAC_CTX_reset(hmac);
+    HMAC_Init_ex(hmac, key.data(), key.size(), EVP_sha512(), NULL);
+    HMAC_Update(hmac, data.data(), data.size());
+    HMAC_Final(hmac, hash.data(), (unsigned int *)(&len));
+    HMAC_CTX_free(hmac);
+#endif
     return hash;
 }


### PR DESCRIPTION
Bring back the preprocessor directive for the HMAC file from master
branch.

Use the feature flag to bring imported OpenSSL targets in scope

Manually redefine the Blake target when OpenSSL is used, as currently it
is swallowed in lib/openssl/crypto folder (which is skipped entirely
when using SYS_OPENSSL)