### PR TITLE
Handle "unsupported in db by libcore" messages appropriately

### DIFF
--- a/ledger-core-cosmos/idl/wallet.djinni
+++ b/ledger-core-cosmos/idl/wallet.djinni
@@ -94,7 +94,7 @@ CosmosLikeMsgType = enum {
         MsgVote;
         MsgDeposit;
         MsgWithdrawDelegationReward;
-        Unknown;
+        Unsupported;
 }
 
 CosmosLikeMessage = interface +c {

--- a/ledger-core-cosmos/inc/cosmos/CosmosLikeConstants.hpp
+++ b/ledger-core-cosmos/inc/cosmos/CosmosLikeConstants.hpp
@@ -231,7 +231,7 @@ namespace ledger {
                                                 return constants::kMsgDeposit;
                                         case MsgType::MSGWITHDRAWDELEGATIONREWARD:
                                                 return constants::kMsgWithdrawDelegationReward;
-                                        case MsgType::UNKNOWN:
+                                        case MsgType::UNSUPPORTED:
                                         default:
                                                 return "";
                                 }
@@ -259,7 +259,7 @@ namespace ledger {
                                 } else if (strings_equal(string, constants::kMsgWithdrawDelegationReward)) {
                                         return MsgType::MSGWITHDRAWDELEGATIONREWARD;
                                 } else {
-                                        return MsgType::UNKNOWN;
+                                        return MsgType::UNSUPPORTED;
                                 }
                         }
                 }

--- a/ledger-core-cosmos/inc/cosmos/api_impl/CosmosLikeOperation.hpp
+++ b/ledger-core-cosmos/inc/cosmos/api_impl/CosmosLikeOperation.hpp
@@ -48,10 +48,6 @@ namespace ledger {
 
             public:
 
-                // TODO [refacto] Remove these, only use CosmosLikeTransactionApi::_txData and CosmosLikeMessage::_msgData
-                ledger::core::cosmos::Transaction txData;
-                ledger::core::cosmos::Message msgData;
-
                 CosmosLikeOperation() = default;
 
                 CosmosLikeOperation(ledger::core::cosmos::Transaction const& tx,

--- a/ledger-core-cosmos/inc/cosmos/cosmos.hpp
+++ b/ledger-core-cosmos/inc/cosmos/cosmos.hpp
@@ -71,6 +71,8 @@ namespace ledger {
                         using MsgDeposit = api::CosmosLikeMsgDeposit;
                         using MsgWithdrawDelegationReward = api::CosmosLikeMsgWithdrawDelegationReward;
 
+                        struct MsgUnsupported {};
+
                         using MessageContent = boost::variant<
                                 MsgSend,
                                 MsgDelegate,
@@ -79,7 +81,8 @@ namespace ledger {
                                 MsgSubmitProposal,
                                 MsgVote,
                                 MsgDeposit,
-                                MsgWithdrawDelegationReward
+                                MsgWithdrawDelegationReward,
+                                MsgUnsupported
                                 >;
 
                         struct Message {

--- a/ledger-core-cosmos/src/cosmos/CosmosLikeAccount.cpp
+++ b/ledger-core-cosmos/src/cosmos/CosmosLikeAccount.cpp
@@ -112,7 +112,7 @@ namespace ledger {
                                 } break;
                                 case api::CosmosLikeMsgType::MSGVOTE:
                                 case api::CosmosLikeMsgType::MSGWITHDRAWDELEGATIONREWARD:
-                                default:
+                                case api::CosmosLikeMsgType::UNSUPPORTED:
                                         // No amount-like data for these types of operation
                                 break;
                         }

--- a/ledger-core-cosmos/src/cosmos/CosmosLikeAccount.cpp
+++ b/ledger-core-cosmos/src/cosmos/CosmosLikeAccount.cpp
@@ -175,7 +175,7 @@ namespace ledger {
 
                                 auto inserted = CosmosLikeOperationDatabaseHelper::putOperation(sql, operation);
                                 if (inserted) {
-                                        CosmosLikeOperationDatabaseHelper::updateOperation(sql, operation.uid, operation.msgData.uid);
+                                        CosmosLikeOperationDatabaseHelper::updateOperation(sql, operation.uid, msg.uid);
                                         emitNewOperationEvent(operation);
                                 }
                        }

--- a/ledger-core-cosmos/src/cosmos/CosmosLikeMessage.cpp
+++ b/ledger-core-cosmos/src/cosmos/CosmosLikeMessage.cpp
@@ -122,8 +122,7 @@ namespace ledger {
 		}
 
 		api::CosmosLikeMsgType CosmosLikeMessage::getMessageType() const {
-			auto msgType = getRawMessageType();
-			return cosmos::stringToMsgType(msgType.c_str());
+			return cosmos::stringToMsgType(_msgData.type.c_str());
 		}
 
 		std::string CosmosLikeMessage::getRawMessageType() const {
@@ -358,14 +357,12 @@ namespace ledger {
 			return boost::get<cosmos::MsgSubmitProposal>(cosmosMsg->getRawData().content);
 		}
 
-
 		std::shared_ptr<api::CosmosLikeMessage> api::CosmosLikeMessage::wrapMsgVote(const api::CosmosLikeMsgVote & msgContent) {
 			cosmos::Message msg;
 			msg.type = kMsgVote;
 			msg.content = msgContent;
 			return std::make_shared<::ledger::core::CosmosLikeMessage>(msg);
 		}
-
 
 		api::CosmosLikeMsgVote api::CosmosLikeMessage::unwrapMsgVote(const std::shared_ptr<api::CosmosLikeMessage> & msg) {
 			auto cosmosMsg = std::dynamic_pointer_cast<ledger::core::CosmosLikeMessage>(msg);
@@ -390,14 +387,12 @@ namespace ledger {
 			return boost::get<cosmos::MsgDeposit>(cosmosMsg->getRawData().content);
 		}
 
-
 		std::shared_ptr<api::CosmosLikeMessage> api::CosmosLikeMessage::wrapMsgWithdrawDelegationReward(const api::CosmosLikeMsgWithdrawDelegationReward & msgContent) {
 			cosmos::Message msg;
 			msg.type = kMsgWithdrawDelegationReward;
 			msg.content = msgContent;
 			return std::make_shared<::ledger::core::CosmosLikeMessage>(msg);
 		}
-
 
     	api::CosmosLikeMsgWithdrawDelegationReward api::CosmosLikeMessage::unwrapMsgWithdrawDelegationReward(const std::shared_ptr<api::CosmosLikeMessage> & msg) {
 			auto cosmosMsg = std::dynamic_pointer_cast<ledger::core::CosmosLikeMessage>(msg);

--- a/ledger-core-cosmos/src/cosmos/api_impl/CosmosLikeOperation.cpp
+++ b/ledger-core-cosmos/src/cosmos/api_impl/CosmosLikeOperation.cpp
@@ -45,15 +45,12 @@ namespace ledger {
                                                  ledger::core::cosmos::Message const& msg) :
             //Operation(account), // TODO Need this?
             _txApi(std::make_shared<CosmosLikeTransactionApi>(tx)),
-            _msgApi(std::make_shared<CosmosLikeMessage>(msg)),
-            txData(tx),
-            msgData(msg)
+            _msgApi(std::make_shared<CosmosLikeMessage>(msg))
         {
             /* TODO Complete missing info for _txApi ?
                 api::Currency _currency;
                 std::string _accountNumber;
                 std::string _accountSequence;
-                cosmos::Transaction _txData;
                 std::vector<uint8_t> _rSignature;
                 std::vector<uint8_t> _sSignature;
                 std::vector<uint8_t> _signingPubKey;
@@ -61,19 +58,17 @@ namespace ledger {
         }
 
         void CosmosLikeOperation::setTransactionData(ledger::core::cosmos::Transaction const& tx) {
-            txData = tx;
             if (_txApi == nullptr) {
                 _txApi = std::make_shared<CosmosLikeTransactionApi>(tx);
             }
-            std::static_pointer_cast<CosmosLikeTransactionApi>(_txApi)->setRawData(txData);
+            std::static_pointer_cast<CosmosLikeTransactionApi>(_txApi)->setRawData(tx);
         }
 
         void CosmosLikeOperation::setMessageData(ledger::core::cosmos::Message const& msg) {
-            msgData = msg;
             if (_msgApi == nullptr) {
                 _msgApi = std::make_shared<CosmosLikeMessage>(msg);
             }
-            std::static_pointer_cast<CosmosLikeMessage>(_msgApi)->setRawData(msgData);
+            std::static_pointer_cast<CosmosLikeMessage>(_msgApi)->setRawData(msg);
         }
 
 		std::shared_ptr<api::CosmosLikeTransaction> CosmosLikeOperation::getTransaction() {

--- a/ledger-core-cosmos/src/cosmos/api_impl/CosmosLikeTransactionApi.cpp
+++ b/ledger-core-cosmos/src/cosmos/api_impl/CosmosLikeTransactionApi.cpp
@@ -103,11 +103,6 @@ namespace ledger {
         CosmosLikeTransactionApi & CosmosLikeTransactionApi::setMessages(const std::vector<std::shared_ptr<api::CosmosLikeMessage>> & cmessages) {
             auto result = std::vector<cosmos::Message>();
             for (auto& message : cmessages) {
-                if (message->getMessageType() == api::CosmosLikeMsgType::UNKNOWN) {
-                    throw Exception(
-                        api::ErrorCode::INVALID_ARGUMENT,
-                        fmt::format("Unknown '{}' message", message->getRawMessageType()));
-                }
                 auto concrete_message = std::dynamic_pointer_cast<CosmosLikeMessage>(message);
                 if (!concrete_message) {
                     throw Exception(

--- a/ledger-core-cosmos/src/cosmos/transaction_builders/CosmosLikeTransactionBuilder.cpp
+++ b/ledger-core-cosmos/src/cosmos/transaction_builders/CosmosLikeTransactionBuilder.cpp
@@ -413,10 +413,13 @@ namespace ledger {
                                     buildMsgWithdrawDelegatationRewardFromRawMessage(msgObject)));
                                 break;
                             default:
-                                throw Exception(
-                                    api::ErrorCode::INVALID_ARGUMENT,
-                                    fmt::format("unknown message {} while parsing transaction", getString(msgObject, kType)));
-                                break;
+                            {
+                                cosmos::Message msg;
+                                msg.type = getString(msgObject, kType);
+                                msg.content = cosmos::MsgUnsupported();
+                                messages.push_back(std::make_shared<::ledger::core::CosmosLikeMessage>(msg));
+                            }
+                            break;
                         }
                     }
                 }

--- a/ledger-core-cosmos/test/Fixtures.cpp
+++ b/ledger-core-cosmos/test/Fixtures.cpp
@@ -1,5 +1,8 @@
 #include "Fixtures.hpp"
 
+#include <cosmos/CosmosLikeConstants.hpp>
+#include <cosmos/api/CosmosLikeVoteOption.hpp>
+
 namespace ledger {
         namespace testing {
                 namespace cosmos {
@@ -22,8 +25,20 @@ namespace ledger {
                                 return std::dynamic_pointer_cast<CosmosLikeAccount>(::wait(wallet->newAccountWithExtendedKeyInfo(i)));
                         }
 
+                        void setupDelegateMessage(Message& msg, const std::chrono::system_clock::time_point& timeRef) {
+                                // TODO
+                        }
+
+                        void setupDepositMessage(Message& msg, const std::chrono::system_clock::time_point& timeRef) {
+                                // TODO
+                        }
+
+                        void setupRedelegateMessage(Message& msg, const std::chrono::system_clock::time_point& timeRef) {
+                                // TODO
+                        }
+
                         void setupSendMessage(Message& msg, const std::chrono::system_clock::time_point& timeRef) {
-                                msg.type = "cosmos-sdk/MsgSend";
+                                msg.type = constants::kMsgSend;
                                 MsgSend sendMsg;
                                 sendMsg.fromAddress = "cosmos155svs6sgxe55rnvs6ghprtqu0mh69kehrn0dqr";
                                 sendMsg.toAddress = "cosmos1sd4tl9aljmmezzudugs7zlaya7pg2895tyn79r";
@@ -31,7 +46,28 @@ namespace ledger {
                                 msg.content = sendMsg;
                         }
 
-                        void setupTransactionWithSingleMessage(Transaction& tx, const Message& msg, const std::chrono::system_clock::time_point& timeRef) {
+                        void setupSubmitProposalMessage(Message& msg, const std::chrono::system_clock::time_point& timeRef) {
+                                // TODO
+                        }
+
+                        void setupUndelegateMessage(Message& msg, const std::chrono::system_clock::time_point& timeRef) {
+                                // TODO
+                        }
+
+                        void setupVoteMessage(Message& msg, const std::chrono::system_clock::time_point& timeRef) {
+                                msg.type = constants::kMsgVote;
+                                MsgVote voteMsg;
+                                voteMsg.voter = "cosmos155svs6sgxe55rnvs6ghprtqu0mh69kehrn0dqr";
+                                voteMsg.proposalId = "42";
+                                voteMsg.option = api::CosmosLikeVoteOption::NO;
+                                msg.content = voteMsg;
+                        }
+
+                        void setupWithdrawDelegationRewardMessage(Message& msg, const std::chrono::system_clock::time_point& timeRef) {
+                                // TODO
+                        }
+
+                        void setupTransaction(Transaction& tx, const std::vector<Message>& msgs, const std::chrono::system_clock::time_point& timeRef) {
                                 tx.hash = "A1E44688B429AF17322EC33CE62876FA415EFC8D9244A2F51454BD025F416594";
                                 api::Block block;
                                 block.blockHash = "52B39D45B438C6995CD448B09963954883B0F7A57E9EFC7A95E0A6C5BAC09C00";
@@ -44,12 +80,26 @@ namespace ledger {
                                 tx.gasUsed = BigInt(26826);
                                 tx.timestamp = timeRef;
                                 tx.memo = "Sent by Ledger";
-                                tx.messages.push_back(msg);
-                                MessageLog log;
-                                log.messageIndex = 0;
-                                log.success = true;
-                                log.log = "Success";
-                                tx.logs.push_back(log);
+                                for (const auto& msg : msgs) {
+                                        tx.messages.push_back(msg);
+                                        MessageLog log;
+                                        log.messageIndex = 0;
+                                        log.success = true;
+                                        log.log = "Success";
+                                        tx.logs.push_back(log);
+                                }
+                        }
+
+                        void assertSameDelegateMessage(const Message& msgRef, const Message& msgResult) {
+                                // TODO
+                        }
+
+                        void assertSameDepositMessage(const Message& msgRef, const Message& msgResult) {
+                                // TODO
+                        }
+
+                        void assertSameRedelegateMessage(const Message& msgRef, const Message& msgResult) {
+                                // TODO
                         }
 
                         void assertSameSendMessage(const Message& msgRef, const Message& msgResult) {
@@ -62,7 +112,27 @@ namespace ledger {
                                 EXPECT_EQ(sendMsgResult.amount[0].denom, sendMsgRef.amount[0].denom);
                         }
 
-                        void assertSameTransactionWithSingleMessage(const Transaction& txRef, const Transaction& txResult) {
+                        void assertSameSubmitProposalMessage(const Message& msgRef, const Message& msgResult) {
+                                // TODO
+                        }
+
+                        void assertSameUndelegateMessage(const Message& msgRef, const Message& msgResult) {
+                                // TODO
+                        }
+
+                        void assertSameVoteMessage(const Message& msgRef, const Message& msgResult) {
+                                const auto& voteMsgRef = boost::get<MsgVote>(msgRef.content);
+                                const auto& voteMsgResult = boost::get<MsgVote>(msgResult.content);
+                                EXPECT_EQ(voteMsgResult.voter, voteMsgRef.voter);
+                                EXPECT_EQ(voteMsgResult.proposalId, voteMsgRef.proposalId);
+                                EXPECT_EQ(voteMsgResult.option, voteMsgRef.option);
+                        }
+
+                        void assertSameWithdrawDelegationRewardMessage(const Message& msgRef, const Message& msgResult) {
+                                // TODO
+                        }
+
+                        void assertSameTransaction(const Transaction& txRef, const Transaction& txResult) {
 
                                 EXPECT_EQ(txResult.hash, txRef.hash);
                                 EXPECT_EQ(txResult.timestamp, txRef.timestamp);
@@ -79,13 +149,41 @@ namespace ledger {
                                 EXPECT_EQ(txResult.fee.gas, txRef.fee.gas);
                                 EXPECT_EQ(txResult.gasUsed.hasValue(), txRef.gasUsed.hasValue());
                                 EXPECT_EQ(txResult.gasUsed.getValue().to_string(), txRef.gasUsed.getValue().to_string());
-
-                                EXPECT_EQ(txResult.messages.size(), 1);
-                                EXPECT_EQ(txResult.messages[0].type, txRef.messages[0].type);
-
                                 EXPECT_EQ(txResult.memo, txRef.memo);
-                                EXPECT_EQ(txResult.logs.size(), 1);
-                                EXPECT_EQ(txResult.logs[0].success, txRef.logs[0].success);
+
+                                EXPECT_EQ(txResult.messages.size(), txRef.messages.size());
+                                EXPECT_EQ(txResult.logs.size(), txRef.logs.size());
+                                for (int i=0 ; i<txResult.messages.size() ; i++) {
+                                        EXPECT_EQ(txResult.messages[i].type, txRef.messages[i].type);
+                                        switch (ledger::core::cosmos::stringToMsgType(txResult.messages[i].type.c_str())) {
+                                                case (api::CosmosLikeMsgType::MSGDELEGATE):
+                                                        assertSameDelegateMessage(txRef.messages[i], txResult.messages[i]);
+                                                        break;
+                                                case (api::CosmosLikeMsgType::MSGDEPOSIT):
+                                                        assertSameDepositMessage(txRef.messages[i], txResult.messages[i]);
+                                                        break;
+                                                case (api::CosmosLikeMsgType::MSGREDELEGATE):
+                                                        assertSameRedelegateMessage(txRef.messages[i], txResult.messages[i]);
+                                                        break;
+                                                case (api::CosmosLikeMsgType::MSGSEND):
+                                                        assertSameSendMessage(txRef.messages[i], txResult.messages[i]);
+                                                        break;
+                                                case (api::CosmosLikeMsgType::MSGSUBMITPROPOSAL):
+                                                        assertSameSubmitProposalMessage(txRef.messages[i], txResult.messages[i]);
+                                                        break;
+                                                case (api::CosmosLikeMsgType::MSGUNDELEGATE):
+                                                        assertSameUndelegateMessage(txRef.messages[i], txResult.messages[i]);
+                                                        break;
+                                                case (api::CosmosLikeMsgType::MSGVOTE):
+                                                        assertSameVoteMessage(txRef.messages[i], txResult.messages[i]);
+                                                        break;
+                                                case (api::CosmosLikeMsgType::MSGWITHDRAWDELEGATIONREWARD):
+                                                        assertSameWithdrawDelegationRewardMessage(txRef.messages[i], txResult.messages[i]);
+                                                        break;
+                                                default: break;
+                                        }
+                                        EXPECT_EQ(txResult.logs[i].success, txRef.logs[i].success);
+                                }
                         }
 
                 }

--- a/ledger-core-cosmos/test/Fixtures.cpp
+++ b/ledger-core-cosmos/test/Fixtures.cpp
@@ -22,6 +22,72 @@ namespace ledger {
                                 return std::dynamic_pointer_cast<CosmosLikeAccount>(::wait(wallet->newAccountWithExtendedKeyInfo(i)));
                         }
 
+                        void setupSendMessage(Message& msg, const std::chrono::system_clock::time_point& timeRef) {
+                                msg.type = "cosmos-sdk/MsgSend";
+                                MsgSend sendMsg;
+                                sendMsg.fromAddress = "cosmos155svs6sgxe55rnvs6ghprtqu0mh69kehrn0dqr";
+                                sendMsg.toAddress = "cosmos1sd4tl9aljmmezzudugs7zlaya7pg2895tyn79r";
+                                sendMsg.amount.emplace_back("900000", "uatom");
+                                msg.content = sendMsg;
+                        }
+
+                        void setupTransactionWithSingleMessage(Transaction& tx, const Message& msg, const std::chrono::system_clock::time_point& timeRef) {
+                                tx.hash = "A1E44688B429AF17322EC33CE62876FA415EFC8D9244A2F51454BD025F416594";
+                                api::Block block;
+                                block.blockHash = "52B39D45B438C6995CD448B09963954883B0F7A57E9EFC7A95E0A6C5BAC09C00";
+                                block.currencyName = "atom";
+                                block.height = 744795;
+                                block.time = timeRef;
+                                tx.block = block;
+                                tx.fee.gas = BigInt(30000);
+                                tx.fee.amount.emplace_back("30", "uatom");
+                                tx.gasUsed = BigInt(26826);
+                                tx.timestamp = timeRef;
+                                tx.memo = "Sent by Ledger";
+                                tx.messages.push_back(msg);
+                                MessageLog log;
+                                log.messageIndex = 0;
+                                log.success = true;
+                                log.log = "Success";
+                                tx.logs.push_back(log);
+                        }
+
+                        void assertSameSendMessage(const Message& msgRef, const Message& msgResult) {
+                                const auto& sendMsgRef = boost::get<MsgSend>(msgRef.content);
+                                const auto& sendMsgResult = boost::get<MsgSend>(msgResult.content);
+                                EXPECT_EQ(sendMsgResult.fromAddress, sendMsgRef.fromAddress);
+                                EXPECT_EQ(sendMsgResult.toAddress, sendMsgRef.toAddress);
+                                EXPECT_EQ(sendMsgResult.amount.size(), 1);
+                                EXPECT_EQ(sendMsgResult.amount[0].amount, sendMsgRef.amount[0].amount);
+                                EXPECT_EQ(sendMsgResult.amount[0].denom, sendMsgRef.amount[0].denom);
+                        }
+
+                        void assertSameTransactionWithSingleMessage(const Transaction& txRef, const Transaction& txResult) {
+
+                                EXPECT_EQ(txResult.hash, txRef.hash);
+                                EXPECT_EQ(txResult.timestamp, txRef.timestamp);
+
+                                EXPECT_EQ(txResult.block.hasValue(), txRef.block.hasValue());
+                                EXPECT_EQ(txResult.block.getValue().blockHash, txRef.block.getValue().blockHash);
+                                EXPECT_EQ(txResult.block.getValue().currencyName, txRef.block.getValue().currencyName);
+                                EXPECT_EQ(txResult.block.getValue().height, txRef.block.getValue().height);
+                                EXPECT_EQ(txResult.block.getValue().time, txRef.block.getValue().time);
+
+                                EXPECT_EQ(txResult.fee.amount.size(), 1);
+                                EXPECT_EQ(txResult.fee.amount[0].amount, txRef.fee.amount[0].amount);
+                                EXPECT_EQ(txResult.fee.amount[0].denom, txRef.fee.amount[0].denom);
+                                EXPECT_EQ(txResult.fee.gas, txRef.fee.gas);
+                                EXPECT_EQ(txResult.gasUsed.hasValue(), txRef.gasUsed.hasValue());
+                                EXPECT_EQ(txResult.gasUsed.getValue().to_string(), txRef.gasUsed.getValue().to_string());
+
+                                EXPECT_EQ(txResult.messages.size(), 1);
+                                EXPECT_EQ(txResult.messages[0].type, txRef.messages[0].type);
+
+                                EXPECT_EQ(txResult.memo, txRef.memo);
+                                EXPECT_EQ(txResult.logs.size(), 1);
+                                EXPECT_EQ(txResult.logs[0].success, txRef.logs[0].success);
+                        }
+
                 }
         }
 }

--- a/ledger-core-cosmos/test/Fixtures.hpp
+++ b/ledger-core-cosmos/test/Fixtures.hpp
@@ -25,13 +25,25 @@ namespace ledger {
                                 int32_t index,
                                 const core::api::ExtendedKeyAccountCreationInfo &info);
 
+                        void setupDelegateMessage(Message& msg, const std::chrono::system_clock::time_point& timeRef);                        void setupDepositMessage(Message& msg, const std::chrono::system_clock::time_point& timeRef);
+                        void setupRedelegateMessage(Message& msg, const std::chrono::system_clock::time_point& timeRef);
                         void setupSendMessage(Message& msg, const std::chrono::system_clock::time_point& timeRef);
+                        void setupSubmitProposalMessage(Message& msg, const std::chrono::system_clock::time_point& timeRef);
+                        void setupUndelegateMessage(Message& msg, const std::chrono::system_clock::time_point& timeRef);
+                        void setupVoteMessage(Message& msg, const std::chrono::system_clock::time_point& timeRef);
+                        void setupWithdrawDelegationRewardMessage(Message& msg, const std::chrono::system_clock::time_point& timeRef);
 
-                        void setupTransactionWithSingleMessage(Transaction& tx, const Message& msg, const std::chrono::system_clock::time_point& timeRef);
+                        void setupTransaction(Transaction& tx, const std::vector<Message>& msgs, const std::chrono::system_clock::time_point& timeRef);
 
+                        void assertSameDelegateMessage(const Message& msgRef, const Message& msgResult);
+                        void assertSameDepositMessage(const Message& msgRef, const Message& msgResult);
+                        void assertSameRedelegateMessage(const Message& msgRef, const Message& msgResult);
                         void assertSameSendMessage(const Message& msgRef, const Message& msgResult);
-
-                        void assertSameTransactionWithSingleMessage(const Transaction& txRef, const Transaction& txResult);
+                        void assertSameSubmitProposalMessage(const Message& msgRef, const Message& msgResult);
+                        void assertSameUndelegateMessage(const Message& msgRef, const Message& msgResult);
+                        void assertSameVoteMessage(const Message& msgRef, const Message& msgResult);
+                        void assertSameWithdrawDelegationRewardMessage(const Message& msgRef, const Message& msgResult);
+                        void assertSameTransaction(const Transaction& txRef, const Transaction& txResult);
                 }
         }
 }

--- a/ledger-core-cosmos/test/Fixtures.hpp
+++ b/ledger-core-cosmos/test/Fixtures.hpp
@@ -4,7 +4,10 @@
 #include <integration/BaseFixture.hpp>
 
 #include <cosmos/CosmosLikeAccount.hpp>
+#include <cosmos/cosmos.hpp>
 
+
+using namespace ledger::core::cosmos;
 
 namespace ledger {
         namespace testing {
@@ -21,6 +24,14 @@ namespace ledger {
                                 const std::shared_ptr<core::AbstractWallet>& wallet,
                                 int32_t index,
                                 const core::api::ExtendedKeyAccountCreationInfo &info);
+
+                        void setupSendMessage(Message& msg, const std::chrono::system_clock::time_point& timeRef);
+
+                        void setupTransactionWithSingleMessage(Transaction& tx, const Message& msg, const std::chrono::system_clock::time_point& timeRef);
+
+                        void assertSameSendMessage(const Message& msgRef, const Message& msgResult);
+
+                        void assertSameTransactionWithSingleMessage(const Transaction& txRef, const Transaction& txResult);
                 }
         }
 }

--- a/ledger-core-cosmos/test/db_test.cpp
+++ b/ledger-core-cosmos/test/db_test.cpp
@@ -3,17 +3,16 @@
 #include <cosmos/api_impl/CosmosLikeTransactionApi.hpp>
 #include <cosmos/database/CosmosLikeTransactionDatabaseHelper.hpp>
 #include <cosmos/CosmosLikeOperationQuery.hpp>
-#include <cosmos/CosmosLikeWallet.hpp>
 #include <cosmos/CosmosLikeCurrencies.hpp>
 #include <cosmos/CosmosLikeMessage.hpp>
-#include <cosmos/cosmos.hpp>
+#include <cosmos/CosmosLikeWallet.hpp>
 
 #include <core/Services.hpp>
 #include <core/utils/DateUtils.hpp>
 
 #include <gtest/gtest.h>
 
-using namespace ledger::core::cosmos;
+using namespace ledger::testing::cosmos;
 
 class CosmosDBTests : public BaseFixture {
 public:
@@ -37,65 +36,14 @@ public:
         auto configuration = DynamicObject::newInstance();
         //configuration->putString(api::Configuration::KEYCHAIN_DERIVATION_SCHEME, "44'/<coin_type>'/<account>'/<node>/<address>");
         wallet = std::dynamic_pointer_cast<CosmosLikeWallet>(
-                        wait(walletStore->createWallet("e847815f-488a-4301-b67c-378a5e9c8a61", "atom", configuration)));
+                            wait(walletStore->createWallet("e847815f-488a-4301-b67c-378a5e9c8a61", "atom", configuration)));
 
         auto accountInfo = wait(wallet->getNextAccountCreationInfo());
         EXPECT_EQ(accountInfo.index, 0);
         accountInfo.publicKeys.push_back(hex::toByteArray(ledger::testing::cosmos::DEFAULT_HEX_PUB_KEY));
 
         account = ledger::testing::cosmos::createCosmosLikeAccount(wallet, accountInfo.index, accountInfo);
-
     }
-
-    void setupTestData(Transaction& tx, std::chrono::system_clock::time_point& timeRef) {
-        tx.hash = "A1E44688B429AF17322EC33CE62876FA415EFC8D9244A2F51454BD025F416594";
-        api::Block block;
-        block.blockHash = "52B39D45B438C6995CD448B09963954883B0F7A57E9EFC7A95E0A6C5BAC09C00";
-        block.currencyName = "atom";
-        block.height = 744795;
-        block.time = timeRef;
-        tx.block = block;
-        tx.fee.gas = BigInt(30000);
-        tx.fee.amount.emplace_back("30", "uatom");
-        tx.gasUsed = BigInt(26826);
-        tx.timestamp = timeRef;
-        tx.memo = "Sent by Ledger";
-        Message msg;
-        msg.type = "cosmos-sdk/MsgSend";
-        MsgSend sendMsg;
-        sendMsg.fromAddress = "cosmos155svs6sgxe55rnvs6ghprtqu0mh69kehrn0dqr";
-        sendMsg.toAddress = "cosmos1sd4tl9aljmmezzudugs7zlaya7pg2895tyn79r";
-        sendMsg.amount.emplace_back("900000", "uatom");
-        msg.content = sendMsg;
-        tx.messages.push_back(msg);
-        MessageLog log;
-        log.messageIndex = 0;
-        log.success = true;
-        log.log = "Success";
-        tx.logs.push_back(log);
-    }
-
-    void assertTestResultTransaction(const Transaction& txRef, const Transaction& txResult) {
-        EXPECT_EQ(txResult.hash, txRef.hash);
-        EXPECT_EQ(txResult.block.hasValue(), txRef.block.hasValue());
-        EXPECT_EQ(txResult.block.getValue().blockHash, txRef.block.getValue().blockHash);
-        EXPECT_EQ(txResult.block.getValue().currencyName, txRef.block.getValue().currencyName);
-        EXPECT_EQ(txResult.block.getValue().height, txRef.block.getValue().height);
-        EXPECT_EQ(txResult.block.getValue().time, txRef.block.getValue().time);
-        EXPECT_EQ(txResult.fee.amount.size(), 1);
-        EXPECT_EQ(txResult.fee.amount[0].amount, txRef.fee.amount[0].amount);
-        EXPECT_EQ(txResult.fee.amount[0].denom, txRef.fee.amount[0].denom);
-        EXPECT_EQ(txResult.fee.gas, txRef.fee.gas);
-        EXPECT_EQ(txResult.gasUsed.hasValue(), txRef.gasUsed.hasValue());
-        EXPECT_EQ(txResult.gasUsed.getValue().to_string(), txRef.gasUsed.getValue().to_string());
-        EXPECT_EQ(txResult.timestamp, txRef.timestamp);
-        EXPECT_EQ(txResult.messages.size(), 1);
-        EXPECT_EQ(txResult.messages[0].type, txRef.messages[0].type);
-        EXPECT_EQ(txResult.memo, txRef.memo);
-        EXPECT_EQ(txResult.logs.size(), 1);
-        EXPECT_EQ(txResult.logs[0].success, txRef.logs[0].success);
-    }
-
 };
 
 TEST_F(CosmosDBTests, CosmosDBTest) {
@@ -107,8 +55,11 @@ TEST_F(CosmosDBTests, CosmosDBTest) {
 
     std::chrono::system_clock::time_point timeRef = DateUtils::now();
 
+    Message msg;
+    setupSendMessage(msg, timeRef);
+
     Transaction tx;
-    setupTestData(tx, timeRef);
+    setupTransactionWithSingleMessage(tx, msg, timeRef);
 
     // Test writing into DB
     {
@@ -123,7 +74,7 @@ TEST_F(CosmosDBTests, CosmosDBTest) {
         auto result = CosmosLikeTransactionDatabaseHelper::getTransactionByHash(sql, tx.hash, txRetrieved);
         EXPECT_EQ(result, true);
 
-        assertTestResultTransaction(tx, txRetrieved);
+        assertSameTransactionWithSingleMessage(tx, txRetrieved);
 
         // TODO Test other (all?) message types
         auto sendMsg = boost::get<MsgSend>(tx.messages[0].content);
@@ -145,8 +96,11 @@ TEST_F(CosmosDBTests, CosmosOperationQueryTest) {
 
     std::chrono::system_clock::time_point timeRef = DateUtils::now();
 
+    Message msg;
+    setupSendMessage(msg, timeRef);
+
     Transaction tx;
-    setupTestData(tx, timeRef);
+    setupTransactionWithSingleMessage(tx, msg, timeRef);
 
     {
         soci::session sql(services->getDatabaseSessionPool()->getPool());
@@ -177,15 +131,42 @@ TEST_F(CosmosDBTests, CosmosOperationQueryTest) {
         auto cosmosOp = std::dynamic_pointer_cast<CosmosLikeOperation>(op);
 
         auto txRetrieved = std::dynamic_pointer_cast<CosmosLikeTransactionApi>(cosmosOp->getTransaction())->getRawData();
-        assertTestResultTransaction(tx, txRetrieved);
+        assertSameTransactionWithSingleMessage(tx, txRetrieved);
 
-        auto msgRetrieved = std::dynamic_pointer_cast<CosmosLikeMessage>(cosmosOp->getMessage())->getRawData();
-        auto sendMsg = boost::get<MsgSend>(tx.messages[0].content);
-        auto sendMsgRetrieved = boost::get<MsgSend>(msgRetrieved.content);
-        EXPECT_EQ(sendMsgRetrieved.fromAddress, sendMsg.fromAddress);
-        EXPECT_EQ(sendMsgRetrieved.toAddress, sendMsg.toAddress);
-        EXPECT_EQ(sendMsgRetrieved.amount.size(), 1);
-        EXPECT_EQ(sendMsgRetrieved.amount[0].amount, sendMsg.amount[0].amount);
-        EXPECT_EQ(sendMsgRetrieved.amount[0].denom, sendMsg.amount[0].denom);
+        assertSameSendMessage(tx.messages[0], txRetrieved.messages[0]);
+    }
+}
+
+TEST_F(CosmosDBTests, UnsuportedMsgTypeTest) {
+    std::shared_ptr<Services> services;
+    std::shared_ptr<CosmosLikeAccount> account;
+    std::shared_ptr<CosmosLikeWallet> wallet;
+    setupTest(services, account, wallet);
+
+    std::chrono::system_clock::time_point timeRef = DateUtils::now();
+
+    Message msg;
+    setupSendMessage(msg, timeRef);
+
+    Transaction tx;
+    setupTransactionWithSingleMessage(tx, msg, timeRef);
+
+    // Change message type
+    tx.messages[0].type = "unknown-message-type";
+
+    {
+        soci::session sql(services->getDatabaseSessionPool()->getPool());
+        account->putTransaction(sql, tx);
+    }
+
+    {
+        auto ops = wait(std::dynamic_pointer_cast<CosmosLikeOperationQuery>(account->queryOperations()->complete())->execute());
+        EXPECT_EQ(ops.size(), 1);
+
+        auto op = ops[0];
+        auto cosmosOp = std::dynamic_pointer_cast<CosmosLikeOperation>(op);
+        auto txRetrieved = std::dynamic_pointer_cast<CosmosLikeTransactionApi>(cosmosOp->getTransaction())->getRawData();
+
+        assertSameTransactionWithSingleMessage(tx, txRetrieved);
     }
 }


### PR DESCRIPTION
Stop throwing exceptions for now, and record the message to expose the very bare minimum in case an unsupported message comes in the account history to help debug and prevent quiproquos