### PR TITLE
[cosmos] Add tests for balance types

### DIFF
--- a/core/src/wallet/cosmos/CosmosLikeAccount.cpp
+++ b/core/src/wallet/cosmos/CosmosLikeAccount.cpp
@@ -347,16 +347,7 @@ namespace ledger {
                 }
 
                 FuturePtr<Amount> CosmosLikeAccount::getBalance() {
-                    auto currency = getWallet()->getCurrency();
-                    return _explorer->getTotalBalance(_keychain->getAddress()->toBech32())
-                            .mapPtr<Amount>(
-                                    getContext(),
-                                    [currency](const auto& rawAmount){
-                                return std::make_shared<Amount>(
-                                    currency,
-                                    0,
-                                    *rawAmount);
-                                    });
+                        return getTotalBalance();
                 }
 
                 std::shared_ptr<api::OperationQuery> CosmosLikeAccount::queryOperations() {

--- a/core/src/wallet/cosmos/CosmosLikeAccount.cpp
+++ b/core/src/wallet/cosmos/CosmosLikeAccount.cpp
@@ -604,5 +604,70 @@ namespace ledger {
                                                                               buildFunction);
                 }
 
+                FuturePtr<Amount> CosmosLikeAccount::getTotalBalance() const {
+                    auto currency = getWallet()->getCurrency();
+                    return _explorer->getTotalBalance(_keychain->getAddress()->toBech32())
+                            .mapPtr<Amount>(
+                                    getContext(),
+                                    [currency](const auto& rawAmount){
+                                return std::make_shared<Amount>(
+                                    currency,
+                                    0,
+                                    *rawAmount);
+                                    });
+                }
+
+                FuturePtr<Amount> CosmosLikeAccount::getDelegatedBalance() const {
+                    auto currency = getWallet()->getCurrency();
+                    return _explorer->getDelegatedBalance(_keychain->getAddress()->toBech32())
+                            .mapPtr<Amount>(
+                                    getContext(),
+                                    [currency](const auto& rawAmount){
+                                return std::make_shared<Amount>(
+                                    currency,
+                                    0,
+                                    *rawAmount);
+                                    });
+                }
+
+                FuturePtr<Amount> CosmosLikeAccount::getPendingRewards() const {
+                    auto currency = getWallet()->getCurrency();
+                    return _explorer->getPendingRewards(_keychain->getAddress()->toBech32())
+                            .mapPtr<Amount>(
+                                    getContext(),
+                                    [currency](const auto& rawAmount){
+                                return std::make_shared<Amount>(
+                                    currency,
+                                    0,
+                                    *rawAmount);
+                                    });
+                }
+
+                FuturePtr<Amount> CosmosLikeAccount::getUnbondingBalance() const {
+                    auto currency = getWallet()->getCurrency();
+                    return _explorer->getUnbondingBalance(_keychain->getAddress()->toBech32())
+                            .mapPtr<Amount>(
+                                    getContext(),
+                                    [currency](const auto& rawAmount){
+                                return std::make_shared<Amount>(
+                                    currency,
+                                    0,
+                                    *rawAmount);
+                                    });
+                }
+
+                FuturePtr<Amount> CosmosLikeAccount::getSpendableBalance() const {
+                    auto currency = getWallet()->getCurrency();
+                    return _explorer->getSpendableBalance(_keychain->getAddress()->toBech32())
+                            .mapPtr<Amount>(
+                                    getContext(),
+                                    [currency](const auto& rawAmount){
+                                return std::make_shared<Amount>(
+                                    currency,
+                                    0,
+                                    *rawAmount);
+                                    });
+                }
+
         }
 }

--- a/core/src/wallet/cosmos/CosmosLikeAccount.hpp
+++ b/core/src/wallet/cosmos/CosmosLikeAccount.hpp
@@ -108,6 +108,13 @@ namespace ledger {
 
                                 std::shared_ptr<api::OperationQuery> queryOperations() override;
                                 void getEstimatedGasLimit(const std::shared_ptr<api::CosmosLikeTransaction> &transaction, const std::shared_ptr<api::BigIntCallback> &callback) override;
+
+                                FuturePtr<Amount> getTotalBalance() const;
+                                FuturePtr<Amount> getDelegatedBalance() const;
+                                FuturePtr<Amount> getPendingRewards() const;
+                                FuturePtr<Amount> getUnbondingBalance() const;
+                                FuturePtr<Amount> getSpendableBalance() const;
+
                         private:
                                 std::shared_ptr<CosmosLikeAccount> getSelf();
 

--- a/core/test/integration/CMakeLists.txt
+++ b/core/test/integration/CMakeLists.txt
@@ -204,6 +204,7 @@ add_test (NAME ledger-core-integration-TezosMakeTransaction.ParseSignedRawOrigin
 add_test (NAME ledger-core-integration-TezosLikeWalletSynchronization.MediumXpubSynchronization COMMAND ledger-core-integration-tests --gtest_filter=TezosLikeWalletSynchronization.MediumXpubSynchronization)
 
 add_test (NAME ledger-core-integration-CosmosLikeWalletSynchronization.MediumXpubSynchronization COMMAND ledger-core-integration-tests --gtest_filter=CosmosLikeWalletSynchronization.MediumXpubSynchronization)
+add_test (NAME ledger-core-integration-CosmosLikeWalletSynchronization.Balances COMMAND ledger-core-integration-tests --gtest_filter=CosmosLikeWalletSynchronization.Balances)
 add_test (NAME ledger-core-integration-CosmosLikeWalletSynchronization.GetAccountWithExplorer COMMAND ledger-core-integration-tests --gtest_filter=CosmosLikeWalletSynchronization.GetAccountWithExplorer)
 add_test (NAME ledger-core-integration-CosmosLikeWalletSynchronization.GetWithdrawDelegationRewardWithExplorer COMMAND ledger-core-integration-tests --gtest_filter=CosmosLikeWalletSynchronization.GetWithdrawDelegationRewardWithExplorer)
 add_test (NAME ledger-core-integration-CosmosLikeWalletSynchronization.GetErrorTransaction COMMAND ledger-core-integration-tests --gtest_filter=CosmosLikeWalletSynchronization.GetErrorTransaction)


### PR DESCRIPTION
Making the tests demanded the creation of an interface to access the
balances from the CosmosLikeAccount class.