### PR TITLE
Inflate MsgMultiSend and other missing types

### DIFF
--- a/.circleci/build_lib.sh
+++ b/.circleci/build_lib.sh
@@ -178,7 +178,7 @@ cmake $cmake_params ../lib-ledger-core
 echo "======> Build for $unamestr in $BUILD_CONFIG mode"
 if [ "$1" == "ios" ]; then
     echo " >>> Starting iOS build for architecture ${ARCH} with toolchain ${TOOLCHAIN_NAME} for ${OSX_SYSROOT}"
-    xcodebuild -project ledger-core.xcodeproj -configuration Release -jobs 4
+    xcodebuild -project ledger-core.xcodeproj -configuration Release -jobs 2
 else
-    make -j4
+    make -j2
 fi

--- a/core/src/database/migrations.cpp
+++ b/core/src/database/migrations.cpp
@@ -849,6 +849,16 @@ namespace ledger {
                 "depositor VARCHAR(255)"
                 ")";
 
+            sql << "CREATE TABLE cosmos_multisend_io("
+                "message_uid NOT NULL REFERENCES cosmos_messages(uid),"
+                // not null when input
+                "from_address VARCHAR(255),"
+                // not null when output
+                "to_address VARCHAR(255),"
+                "amount NOT NULL VARCHAR(255)"
+                ")"
+                ;
+
             sql << "CREATE TABLE cosmos_operations("
                 "uid VARCHAR(255) PRIMARY KEY NOT NULL REFERENCES operations(uid) ON DELETE CASCADE,"
                 "message_uid VARCHAR(255) NOT NULL REFERENCES cosmos_messages(uid)"

--- a/core/src/database/migrations.cpp
+++ b/core/src/database/migrations.cpp
@@ -825,9 +825,8 @@ namespace ledger {
                 "from_address VARCHAR(255),"
                 // not null when output
                 "to_address VARCHAR(255),"
-                "amount NOT NULL VARCHAR(255)"
-                ")"
-                ;
+                "amount VARCHAR(255) NOT NULL"
+                ")";
 
             sql << "CREATE TABLE cosmos_operations("
                 "uid VARCHAR(255) PRIMARY KEY NOT NULL REFERENCES operations(uid) ON DELETE CASCADE,"
@@ -845,6 +844,8 @@ namespace ledger {
             sql << "DROP TABLE cosmos_currencies";
 
             sql << "DROP TABLE cosmos_messages";
+
+            sql << "DROP TABLE cosmos_multisend_io";
         }
     }
 }

--- a/core/src/database/migrations.cpp
+++ b/core/src/database/migrations.cpp
@@ -774,50 +774,20 @@ namespace ledger {
                 "memo TEXT"
                 ")";
 
-            // * TODO : handle missing Msg types
+            // * NOTE : Special Msg types
             // ** MsgMultiSend
-            // // MsgMultiSend - high level transaction of the coin module
-            // type MsgMultiSend struct {
-            //  Inputs  []Input  `json:"inputs"`
-            //  Outputs []Output `json:"outputs"`
-            // }
-            // // Input models transaction input
-            // type Input struct {
-            //  Address sdk.AccAddress `json:"address"`
-            //  Coins   sdk.Coins      `json:"coins"`
-            // }
-            // // Output models transaction outputs
-            // type Output struct {
-            //  Address sdk.AccAddress `json:"address"`
-            //  Coins   sdk.Coins      `json:"coins"`
-            // }
+            // MsgMultiSend can have an arbitrary number of inputs and outputs
+            // (only invariant is sum(inputs) == sum(outputs))
+            // Therefore the various inputs and outputs are stored in another
+            // table to avoid varchars longer than 256 bytes
             //
             // ** MsgCreateValidator
-            // // MsgCreateValidator - struct for bonding transactions
-            // type MsgCreateValidator struct {
-            //  Description       Description    `json:"description"`
-            //  Commission        CommissionMsg  `json:"commission"`
-            //  MinSelfDelegation sdk.Int        `json:"min_self_delegation"`
-            //  DelegatorAddress  sdk.AccAddress `json:"delegator_address"`
-            //  ValidatorAddress  sdk.ValAddress `json:"validator_address"`
-            //  PubKey            crypto.PubKey  `json:"pubkey"`
-            //  Value             sdk.Coin       `json:"value"`
-            // }
+            // This message is not handled in database, and behaviour with these
+            // messages is undefined.
             //
             // ** MsgEditValidator
-            // // MsgEditValidator - struct for editing a validator
-            // type MsgEditValidator struct {
-            //  Description
-            //  ValidatorAddress sdk.ValAddress `json:"address"`
-            //
-            //  // We pass a reference to the new commission rate and min self delegation as it's not mandatory to
-            //  // update. If not updated, the deserialized rate will be zero with no way to
-            //  // distinguish if an update was intended.
-            //  //
-            //  // REF: #2373
-            //  CommissionRate    *sdk.Dec `json:"commission_rate"`
-            //  MinSelfDelegation *sdk.Int `json:"min_self_delegation"`
-            // }
+            // This message is not handled in database, and behaviour with these
+            // messages is undefined.
             sql << "CREATE TABLE cosmos_messages("
                 "uid VARCHAR(255) PRIMARY KEY NOT NULL,"
                 "transaction_uid VARCHAR(255) NOT NULL "

--- a/core/src/wallet/cosmos/database/CosmosLikeTransactionDatabaseHelper.cpp
+++ b/core/src/wallet/cosmos/database/CosmosLikeTransactionDatabaseHelper.cpp
@@ -44,11 +44,15 @@
 
 #include <boost/lexical_cast.hpp>
 
+#include <algorithm>
+#include <unordered_map>
+
+#include <utils/Exception.hpp>
 
 namespace ledger {
     namespace core {
 
-        static void inflateMessage(soci::row const& row, cosmos::Message& msg) {
+        static void inflateMessage(soci::session& sql, soci::row const& row, cosmos::Message& msg) {
             // See Migrations.cpp for column numbers
             const auto COL_UID = 0;
             const auto COL_TXUID = 1;
@@ -149,7 +153,75 @@ namespace ledger {
                         content.validatorAddress = row.get<std::string>(COL_VALADDR);
                     }
                     break;
+                case api::CosmosLikeMsgType::MSGWITHDRAWDELEGATORREWARD:
+                    {
+                        msg.content = cosmos::MsgWithdrawDelegatorReward();
+                        auto &content = boost::get<cosmos::MsgWithdrawDelegatorReward>(msg.content);
+                        content.delegatorAddress = row.get<std::string>(COL_DELADDR);
+                        content.validatorAddress = row.get<std::string>(COL_VALADDR);
+                    }
+                    break;
+                case api::CosmosLikeMsgType::MSGWITHDRAWVALIDATORCOMMISSION:
+                    {
+                        msg.content = cosmos::MsgWithdrawValidatorCommission();
+                        auto &content = boost::get<cosmos::MsgWithdrawValidatorCommission>(msg.content);
+                        content.validatorAddress = row.get<std::string>(COL_VALADDR);
+                    }
+                    break;
+                case api::CosmosLikeMsgType::MSGSETWITHDRAWADDRESS:
+                    {
+                        msg.content = cosmos::MsgSetWithdrawAddress();
+                        auto &content = boost::get<cosmos::MsgSetWithdrawAddress>(msg.content);
+                        content.delegatorAddress = row.get<std::string>(COL_DELADDR);
+                        content.withdrawAddress = row.get<std::string>(COL_TOADDR);
+                    }
+                    break;
+                case api::CosmosLikeMsgType::MSGUNJAIL:
+                    {
+                        msg.content = cosmos::MsgUnjail();
+                        auto &content = boost::get<cosmos::MsgUnjail>(msg.content);
+                        content.validatorAddress = row.get<std::string>(COL_VALADDR);
+                    }
+                    break;
+                case api::CosmosLikeMsgType::MSGMULTISEND:
+                    {
+                        msg.content = cosmos::MsgMultiSend();
+                        auto &content = boost::get<cosmos::MsgMultiSend>(msg.content);
+                        // Make a join on cosmos_multisend_io to fill the message
+                        soci::rowset<soci::row> multiSendRows = (sql.prepare <<
+                                "SELECT * FROM cosmos_multisend_io WHERE message_uid = :msgUid",
+                                soci::use(msg.uid));
+                        // See migrations.cpp for column names
+                        const auto COL_MULTI_FROM = 1;
+                        const auto COL_MULTI_TO = 2;
+                        const auto COL_MULTI_AMT = 3;
+                        for (auto &multiSendRow : multiSendRows) {
+                            const auto inputAddress = multiSendRow.get<Option<std::string>>(COL_MULTI_FROM).getValueOr("");
+                            const auto outputAddress = multiSendRow.get<Option<std::string>>(COL_MULTI_TO).getValueOr("");
+                            if (!inputAddress.empty()) {
+                                cosmos::MultiSendInput newInput;
+                                newInput.fromAddress = inputAddress;
+                                soci::stringToCoins(multiSendRow.get<std::string>(COL_MULTI_TO), newInput.coins);
+                                content.inputs.push_back(newInput);
+                            } else if (!outputAddress.empty()) {
+                                cosmos::MultiSendOutput newOutput;
+                                newOutput.toAddress = outputAddress;
+                                soci::stringToCoins(multiSendRow.get<std::string>(COL_MULTI_TO), newOutput.coins);
+                                content.outputs.push_back(newOutput);
+                            }
+                        }
+                    }
+                    break;
+                case api::CosmosLikeMsgType::MSGEDITVALIDATOR:
+                case api::CosmosLikeMsgType::MSGCREATEVALIDATOR:
+                    {
+                    throw make_exception(
+                        api::ErrorCode::IMPLEMENTATION_IS_MISSING,
+                        "inflate MsgCreateValidator / MsgEditValidator");
+                    }
+                    break;
                 case api::CosmosLikeMsgType::UNSUPPORTED:
+                default:
                     {
                         msg.content = cosmos::MsgUnsupported();
                     }
@@ -208,7 +280,7 @@ namespace ledger {
                 const auto COL_MSG_SUCCESS = 4;
                 const auto COL_MSG_INDEX = 5;
                 cosmos::Message msg;
-                inflateMessage(msgRow, msg);
+                inflateMessage(sql, msgRow, msg);
                 tx.messages.push_back(msg);
 
                 cosmos::MessageLog log;
@@ -383,6 +455,73 @@ namespace ledger {
                     }
                     break;
                 case api::CosmosLikeMsgType::MSGMULTISEND:
+                    {
+                        const auto& m = boost::get<cosmos::MsgMultiSend>(msg.content);
+                        std::vector<cosmos::Coin> totalAmount;
+
+                        // HACK : this snippet left-folds a iterable<vector<cosmos::Coin>>
+                        // into vector<cosmos::Coin> using addition.
+                        // Hopefully transform_reduce or flatten functions can help us later.
+                        // The map intermediate helps for out-of-order denominations.
+                        std::unordered_map<std::string, BigInt> denomToAmt;
+                        std::for_each(
+                            m.inputs.cbegin(),
+                            m.inputs.cend(),
+                            [&denomToAmt](const auto &input) {
+                                std::for_each(
+                                    input.coins.cbegin(),
+                                    input.coins.cend(),
+                                    [&denomToAmt](const auto &amountDenom) {
+                                        auto searchDenom = denomToAmt.find(amountDenom.denom);
+                                        if (searchDenom == denomToAmt.end()) {
+                                            denomToAmt.insert(
+                                                {amountDenom.denom,
+                                                 BigInt::fromString(amountDenom.amount)});
+                                            return;
+                                        }
+                                        searchDenom->second =
+                                            searchDenom->second +
+                                            BigInt::fromString(amountDenom.amount);
+                                    });
+                            });
+                        // Add each pair of denomToAmt into totalAmount
+                        totalAmount.reserve(denomToAmt.size());
+                        for (const auto &pair : denomToAmt) {
+                            totalAmount.emplace_back(pair.second.toString(),pair.first);
+                        }
+
+                        // Insert the global message information in cosmos_messages
+                        const auto coins = soci::coinsToString(totalAmount);
+                        sql << "INSERT INTO cosmos_messages (uid,"
+                               "transaction_uid, message_type, log,"
+                               "success, msg_index, amount) "
+                               "VALUES (:uid, :tuid, :mt, :log, :success, :mi, :fa, :ta, :amount)",
+                               soci::use(msg.uid), soci::use(txUid), soci::use(msg.type), soci::use(log.log),
+                               soci::use(log.success ? 1 : 0), soci::use(log.messageIndex),
+                               soci::use(coins);
+
+                        // Insert each input and each output to the cosmos_multisend_io table
+                        std::for_each(
+                            m.inputs.cbegin(),
+                            m.inputs.cend(),
+                            [&sql, &msg] (const auto& input) {
+                                const auto inputCoins = soci::coinsToString(input.coins);
+                                sql << "INSERT INTO cosmos_multisend_io (uid, from_address, amount) "
+                                    "VALUES (:uid, :fa, :amt)",
+                                    soci::use(msg.uid), soci::use(input.fromAddress), soci::use(inputCoins);
+                            });
+
+                        std::for_each(
+                            m.outputs.cbegin(),
+                            m.outputs.cend(),
+                            [&sql, &msg] (const auto& output) {
+                                const auto outputCoins = soci::coinsToString(output.coins);
+                                sql << "INSERT INTO cosmos_multisend_io (uid, to_address, amount) "
+                                    "VALUES (:uid, :ta, :amt)",
+                                    soci::use(msg.uid), soci::use(output.toAddress), soci::use(outputCoins);
+                            });
+                    }
+                    break;
                 case api::CosmosLikeMsgType::MSGCREATEVALIDATOR:
                 case api::CosmosLikeMsgType::MSGEDITVALIDATOR:
                 case api::CosmosLikeMsgType::UNSUPPORTED:
@@ -506,7 +645,7 @@ namespace ledger {
                     soci::use(msgUid));
 
             for (auto &row : rows) {
-                inflateMessage(row, msg);
+                inflateMessage(sql, row, msg);
                 return true;
             }
 

--- a/core/src/wallet/cosmos/database/CosmosLikeTransactionDatabaseHelper.cpp
+++ b/core/src/wallet/cosmos/database/CosmosLikeTransactionDatabaseHelper.cpp
@@ -216,7 +216,7 @@ namespace ledger {
                 case api::CosmosLikeMsgType::MSGCREATEVALIDATOR:
                     {
                     throw make_exception(
-                        api::ErrorCode::IMPLEMENTATION_IS_MISSING,
+                        api::ErrorCode::UNSUPPORTED_OPERATION,
                         "inflate MsgCreateValidator / MsgEditValidator");
                     }
                     break;

--- a/core/src/wallet/cosmos/database/CosmosLikeTransactionDatabaseHelper.cpp
+++ b/core/src/wallet/cosmos/database/CosmosLikeTransactionDatabaseHelper.cpp
@@ -201,12 +201,12 @@ namespace ledger {
                             if (!inputAddress.empty()) {
                                 cosmos::MultiSendInput newInput;
                                 newInput.fromAddress = inputAddress;
-                                soci::stringToCoins(multiSendRow.get<std::string>(COL_MULTI_TO), newInput.coins);
+                                soci::stringToCoins(multiSendRow.get<std::string>(COL_MULTI_AMT), newInput.coins);
                                 content.inputs.push_back(newInput);
                             } else if (!outputAddress.empty()) {
                                 cosmos::MultiSendOutput newOutput;
                                 newOutput.toAddress = outputAddress;
-                                soci::stringToCoins(multiSendRow.get<std::string>(COL_MULTI_TO), newOutput.coins);
+                                soci::stringToCoins(multiSendRow.get<std::string>(COL_MULTI_AMT), newOutput.coins);
                                 content.outputs.push_back(newOutput);
                             }
                         }
@@ -495,7 +495,7 @@ namespace ledger {
                         sql << "INSERT INTO cosmos_messages (uid,"
                                "transaction_uid, message_type, log,"
                                "success, msg_index, amount) "
-                               "VALUES (:uid, :tuid, :mt, :log, :success, :mi, :fa, :ta, :amount)",
+                               "VALUES (:uid, :tuid, :mt, :log, :success, :mi, :amount)",
                                soci::use(msg.uid), soci::use(txUid), soci::use(msg.type), soci::use(log.log),
                                soci::use(log.success ? 1 : 0), soci::use(log.messageIndex),
                                soci::use(coins);

--- a/core/src/wallet/cosmos/explorers/GaiaCosmosLikeBlockchainExplorer.cpp
+++ b/core/src/wallet/cosmos/explorers/GaiaCosmosLikeBlockchainExplorer.cpp
@@ -208,7 +208,7 @@ namespace ledger {
             std::vector<Future<cosmos::TransactionList>> address_transactions;
             std::transform(addresses.begin(), addresses.end(), std::back_inserter(address_transactions),
                            [&] (const auto& address) -> Future<cosmos::TransactionList> {
-                               return getTransactionsForAddress(address, fromBlockHeight);
+                               return this->getTransactionsForAddress(address, fromBlockHeight);
                            });
             return async::sequence(getContext(), address_transactions)
                 .flatMap<cosmos::TransactionList>(getContext(), [](auto& vector_of_lists) {

--- a/core/test/cosmos/db_test.cpp
+++ b/core/test/cosmos/db_test.cpp
@@ -9,6 +9,7 @@
 #include <wallet/cosmos/CosmosLikeWallet.hpp>
 
 #include <wallet/pool/WalletPool.hpp>
+#include <api/PoolConfiguration.hpp>
 #include <utils/DateUtils.hpp>
 
 #include <gtest/gtest.h>
@@ -22,9 +23,9 @@ public:
      BaseFixture::SetUp();
 #ifdef PG_SUPPORT
      const bool usePostgreSQL = true;
-     configuration->putString(
-         api::PoolConfiguration::DATABASE_NAME, "postgres://localhost:5432/test_db");
-     pool = newDefaultPool("postgres", "", configuration, usePostgreSQL);
+     auto poolConfig = DynamicObject::newInstance();
+     poolConfig->putString(api::PoolConfiguration::DATABASE_NAME, "postgres://localhost:5432/test_db");
+     auto pool = newDefaultPool("postgres", "", poolConfig, usePostgreSQL);
 #else
      pool = newDefaultPool();
 #endif

--- a/core/test/cosmos/transactions_test.cpp
+++ b/core/test/cosmos/transactions_test.cpp
@@ -35,6 +35,7 @@
 #include <wallet/cosmos/CosmosLikeAccount.hpp>
 
 #include <api/CosmosLikeTransactionBuilder.hpp>
+#include <api/PoolConfiguration.hpp>
 #include <api/CosmosLikeMessage.hpp>
 #include <api/StringCallback.hpp>
 
@@ -55,9 +56,9 @@ public:
      BaseFixture::SetUp();
 #ifdef PG_SUPPORT
      const bool usePostgreSQL = true;
-     configuration->putString(
-         api::PoolConfiguration::DATABASE_NAME, "postgres://localhost:5432/test_db");
-     pool = newDefaultPool("postgres", "", configuration, usePostgreSQL);
+     auto poolConfig = DynamicObject::newInstance();
+     poolConfig->putString(api::PoolConfiguration::DATABASE_NAME, "postgres://localhost:5432/test_db");
+     auto pool = newDefaultPool("postgres", "", poolConfig, usePostgreSQL);
 #else
      pool = newDefaultPool();
 #endif

--- a/core/test/integration/synchronization/cosmos_synchronization.cpp
+++ b/core/test/integration/synchronization/cosmos_synchronization.cpp
@@ -39,6 +39,7 @@
 
 #include <api/Configuration.hpp>
 #include <api/KeychainEngines.hpp>
+#include <api/PoolConfiguration.hpp>
 #include <utils/DateUtils.hpp>
 #include <utils/hex.h>
 #include <collections/DynamicObject.hpp>
@@ -85,8 +86,9 @@ public:
 
 #ifdef PG_SUPPORT
     const bool usePostgreSQL = true;
-    configuration->putString(api::PoolConfiguration::DATABASE_NAME, "postgres://localhost:5432/test_db");
-    pool = newDefaultPool("postgres", "", configuration, usePostgreSQL);
+    auto poolConfig = DynamicObject::newInstance();
+    poolConfig->putString(api::PoolConfiguration::DATABASE_NAME, "postgres://localhost:5432/test_db");
+    pool = newDefaultPool("postgres", "", poolConfig, usePostgreSQL);
 #else
     pool = newDefaultPool();
 #endif
@@ -273,8 +275,9 @@ TEST_F(CosmosLikeWalletSynchronization, MediumXpubSynchronization) {
     auto walletName = "e847815f-488a-4301-b67c-378a5e9c8a61";
 #ifdef PG_SUPPORT
     const bool usePostgreSQL = true;
-    configuration->putString(api::PoolConfiguration::DATABASE_NAME, "postgres://localhost:5432/test_db");
-    auto pool = newDefaultPool("postgres", "", configuration, usePostgreSQL);
+    auto poolConfig = DynamicObject::newInstance();
+    poolConfig->putString(api::PoolConfiguration::DATABASE_NAME, "postgres://localhost:5432/test_db");
+    auto pool = newDefaultPool("postgres", "", poolConfig, usePostgreSQL);
 #else
     auto pool = newDefaultPool();
 #endif


### PR DESCRIPTION
MsgMultiSend uses another database to store the arbitrarily sized array
of inputs and outputs for the transaction.

All the missing types in inflateMessage have been added.