### PR TITLE
[Coin 270] CI / warning fixes

### DIFF
--- a/core/src/database/migrations.cpp
+++ b/core/src/database/migrations.cpp
@@ -812,7 +812,7 @@ namespace ledger {
                 "content_description TEXT,"
                 "proposer VARCHAR(255),"
                 // MsgVote
-                "voter VARCHAR(40),"
+                "voter VARCHAR(255),"
                 "proposal_id VARCHAR(255),"
                 "vote_option VARCHAR(255),"
                 // MsgDeposit
@@ -820,7 +820,8 @@ namespace ledger {
                 ")";
 
             sql << "CREATE TABLE cosmos_multisend_io("
-                "message_uid VARCHAR(255) NOT NULL REFERENCES cosmos_messages(uid),"
+                "message_uid VARCHAR(255) NOT NULL "
+                "REFERENCES cosmos_messages(uid) ON DELETE CASCADE ON UPDATE CASCADE,"
                 // not null when input
                 "from_address VARCHAR(255),"
                 // not null when output
@@ -829,23 +830,21 @@ namespace ledger {
                 ")";
 
             sql << "CREATE TABLE cosmos_operations("
-                "uid VARCHAR(255) PRIMARY KEY NOT NULL REFERENCES operations(uid) ON DELETE CASCADE,"
-                "message_uid VARCHAR(255) NOT NULL REFERENCES cosmos_messages(uid)"
+                "uid VARCHAR(255) PRIMARY KEY NOT NULL "
+                "REFERENCES operations(uid) ON DELETE CASCADE,"
+                "message_uid VARCHAR(255) NOT NULL "
+                "REFERENCES cosmos_messages(uid) ON DELETE CASCADE ON UPDATE CASCADE"
                 ")";
         }
 
         template <> void rollback<19>(soci::session& sql, api::DatabaseBackendType type) {
-            sql << "DROP TABLE cosmos_transactions";
-
+            sql << "DROP TABLE cosmos_multisend_io";
             sql << "DROP TABLE cosmos_operations";
-
+            sql << "DROP TABLE cosmos_messages";
+            sql << "DROP TABLE cosmos_transactions";
             sql << "DROP TABLE cosmos_accounts";
-
             sql << "DROP TABLE cosmos_currencies";
 
-            sql << "DROP TABLE cosmos_messages";
-
-            sql << "DROP TABLE cosmos_multisend_io";
         }
     }
 }

--- a/core/src/database/migrations.cpp
+++ b/core/src/database/migrations.cpp
@@ -820,7 +820,7 @@ namespace ledger {
                 ")";
 
             sql << "CREATE TABLE cosmos_multisend_io("
-                "message_uid NOT NULL REFERENCES cosmos_messages(uid),"
+                "message_uid VARCHAR(255) NOT NULL REFERENCES cosmos_messages(uid),"
                 // not null when input
                 "from_address VARCHAR(255),"
                 // not null when output

--- a/core/src/wallet/common/AbstractAddress.cpp
+++ b/core/src/wallet/common/AbstractAddress.cpp
@@ -32,6 +32,7 @@
 #include "AbstractAddress.h"
 #include <utils/Exception.hpp>
 #include <bitcoin/BitcoinLikeAddress.hpp>
+#include <cosmos/CosmosLikeAddress.hpp>
 #include <ethereum/EthereumLikeAddress.h>
 #include <ripple/RippleLikeAddress.h>
 #include <tezos/TezosLikeAddress.h>
@@ -64,6 +65,8 @@ namespace ledger {
             switch (currency.walletType) {
                 case WalletType::BITCOIN:
                     return ledger::core::BitcoinLikeAddress::parse(address, currency);
+                case WalletType::COSMOS:
+                    return ledger::core::CosmosLikeAddress::parse(address, currency);
                 case WalletType::ETHEREUM:
                     return ledger::core::EthereumLikeAddress::parse(address, currency);
                 case WalletType::RIPPLE:
@@ -72,6 +75,8 @@ namespace ledger {
                     return ledger::core::TezosLikeAddress::parse(address, currency);
                 case WalletType::MONERO:
                     throw make_exception(api::ErrorCode::IMPLEMENTATION_IS_MISSING, "MONERO address parser is not implemented yet");
+                default:
+                    throw make_exception(api::ErrorCode::IMPLEMENTATION_IS_MISSING, "Unknown wallet type address parser is needed here.");
             }
         }
 

--- a/core/src/wallet/cosmos/CosmosLikeConstants.hpp
+++ b/core/src/wallet/cosmos/CosmosLikeConstants.hpp
@@ -305,39 +305,52 @@ namespace ledger {
                         }
 
                         static constexpr MsgType stringToMsgType(const char* string) {
-                                if (strings_equal(string, constants::kMsgSend)) {
-                                        return MsgType::MSGSEND;
-                                } else if (strings_equal(string, constants::kMsgDelegate)) {
-                                        return MsgType::MSGDELEGATE;
-                                } else if (strings_equal(string, constants::kMsgUndelegate)) {
-                                        return MsgType::MSGUNDELEGATE;
-                                } else if (strings_equal(string, constants::kMsgBeginRedelegate)) {
-                                        return MsgType::MSGBEGINREDELEGATE;
-                                } else if (strings_equal(string, constants::kMsgSubmitProposal)) {
-                                        return MsgType::MSGSUBMITPROPOSAL;
-                                } else if (strings_equal(string, constants::kMsgVote)) {
-                                        return MsgType::MSGVOTE;
-                                } else if (strings_equal(string, constants::kMsgDeposit)) {
-                                        return MsgType::MSGDEPOSIT;
-                                } else if (strings_equal(string, constants::kMsgWithdrawDelegationReward)) {
-                                        return MsgType::MSGWITHDRAWDELEGATIONREWARD;
-                                } else if (strings_equal(string, constants::kMsgMultiSend)) {
-                                        return MsgType::MSGMULTISEND;
-                                } else if (strings_equal(string, constants::kMsgCreateValidator)) {
-                                        return MsgType::MSGCREATEVALIDATOR;
-                                } else if (strings_equal(string, constants::kMsgEditValidator)) {
-                                        return MsgType::MSGEDITVALIDATOR;
-                                } else if (strings_equal(string, constants::kMsgSetWithdrawAddress)) {
-                                        return MsgType::MSGSETWITHDRAWADDRESS;
-                                } else if (strings_equal(string, constants::kMsgWithdrawDelegatorReward)) {
-                                        return MsgType::MSGWITHDRAWDELEGATORREWARD;
-                                } else if (strings_equal(string, constants::kMsgWithdrawValidatorCommission)) {
-                                        return MsgType::MSGWITHDRAWVALIDATORCOMMISSION;
-                                } else if (strings_equal(string, constants::kMsgUnjail)) {
-                                        return MsgType::MSGUNJAIL;
-                                } else {
-                                        return MsgType::UNSUPPORTED;
-                                }
+                            if (strings_equal(string, constants::kMsgSend)) {
+                                return MsgType::MSGSEND;
+                            }
+                            if (strings_equal(string, constants::kMsgDelegate)) {
+                                return MsgType::MSGDELEGATE;
+                            }
+                            if (strings_equal(string, constants::kMsgUndelegate)) {
+                                return MsgType::MSGUNDELEGATE;
+                            }
+                            if (strings_equal(string, constants::kMsgBeginRedelegate)) {
+                                return MsgType::MSGBEGINREDELEGATE;
+                            }
+                            if (strings_equal(string, constants::kMsgSubmitProposal)) {
+                                return MsgType::MSGSUBMITPROPOSAL;
+                            }
+                            if (strings_equal(string, constants::kMsgVote)) {
+                                return MsgType::MSGVOTE;
+                            }
+                            if (strings_equal(string, constants::kMsgDeposit)) {
+                                return MsgType::MSGDEPOSIT;
+                            }
+                            if (strings_equal(string, constants::kMsgWithdrawDelegationReward)) {
+                                return MsgType::MSGWITHDRAWDELEGATIONREWARD;
+                            }
+                            if (strings_equal(string, constants::kMsgMultiSend)) {
+                                return MsgType::MSGMULTISEND;
+                            }
+                            if (strings_equal(string, constants::kMsgCreateValidator)) {
+                                return MsgType::MSGCREATEVALIDATOR;
+                            }
+                            if (strings_equal(string, constants::kMsgEditValidator)) {
+                                return MsgType::MSGEDITVALIDATOR;
+                            }
+                            if (strings_equal(string, constants::kMsgSetWithdrawAddress)) {
+                                return MsgType::MSGSETWITHDRAWADDRESS;
+                            }
+                            if (strings_equal(string, constants::kMsgWithdrawDelegatorReward)) {
+                                return MsgType::MSGWITHDRAWDELEGATORREWARD;
+                            }
+                            if (strings_equal(string, constants::kMsgWithdrawValidatorCommission)) {
+                                return MsgType::MSGWITHDRAWVALIDATORCOMMISSION;
+                            }
+                            if (strings_equal(string, constants::kMsgUnjail)) {
+                                return MsgType::MSGUNJAIL;
+                            }
+                            return MsgType::UNSUPPORTED;
                         }
 
                         static constexpr const char* voteOptionToChars(api::CosmosLikeVoteOption option) {

--- a/core/src/wallet/cosmos/CosmosLikeConstants.hpp
+++ b/core/src/wallet/cosmos/CosmosLikeConstants.hpp
@@ -350,6 +350,8 @@ namespace ledger {
                                                 return constants::kVoteOptionNoWithVeto;
                                         case api::CosmosLikeVoteOption::YES:
                                                 return constants::kVoteOptionYes;
+                                        default:
+                                                return "unknown";
                                 }
                         }
 

--- a/core/test/cosmos/db_test.cpp
+++ b/core/test/cosmos/db_test.cpp
@@ -25,7 +25,7 @@ public:
      const bool usePostgreSQL = true;
      auto poolConfig = DynamicObject::newInstance();
      poolConfig->putString(api::PoolConfiguration::DATABASE_NAME, "postgres://localhost:5432/test_db");
-     auto pool = newDefaultPool("postgres", "", poolConfig, usePostgreSQL);
+     pool = newDefaultPool("postgres", "", poolConfig, usePostgreSQL);
 #else
      pool = newDefaultPool();
 #endif
@@ -49,6 +49,11 @@ public:
      accountInfo.publicKeys.push_back(hex::toByteArray(DEFAULT_HEX_PUB_KEY));
 
      account = createCosmosLikeAccount(wallet, accountInfo.index, accountInfo);
+ }
+
+ void TearDown() override {
+     wait(pool->freshResetAll());
+     BaseFixture::TearDown();
  }
 
  std::shared_ptr<WalletPool> pool;

--- a/core/test/cosmos/transactions_test.cpp
+++ b/core/test/cosmos/transactions_test.cpp
@@ -35,7 +35,6 @@
 #include <wallet/cosmos/CosmosLikeAccount.hpp>
 
 #include <api/CosmosLikeTransactionBuilder.hpp>
-#include <api/PoolConfiguration.hpp>
 #include <api/CosmosLikeMessage.hpp>
 #include <api/StringCallback.hpp>
 
@@ -49,43 +48,7 @@
 using namespace ledger::testing::cosmos;
 using namespace ledger::core;
 
-class CosmosTransactionTest : public BaseFixture {
-public:
- void SetUp() override
- {
-     BaseFixture::SetUp();
-#ifdef PG_SUPPORT
-     const bool usePostgreSQL = true;
-     auto poolConfig = DynamicObject::newInstance();
-     poolConfig->putString(api::PoolConfiguration::DATABASE_NAME, "postgres://localhost:5432/test_db");
-     pool = newDefaultPool("postgres", "", poolConfig, usePostgreSQL);
-#else
-     pool = newDefaultPool();
-#endif
-     backend->enableQueryLogging(true);
- }
-
- void setupTest(std::shared_ptr<CosmosLikeAccount> &account,
-                std::shared_ptr<CosmosLikeWallet> &wallet)
- {
-     auto configuration = DynamicObject::newInstance();
-     configuration->putString(
-         api::Configuration::KEYCHAIN_DERIVATION_SCHEME,
-         "44'/<coin_type>'/<account>'/<node>/<address>");
-     wallet = std::dynamic_pointer_cast<CosmosLikeWallet>(
-         wait(pool->createWallet("e847815f-488a-4301-b67c-378a5e9c8a61", "atom", configuration)));
-
-     auto accountInfo = wait(wallet->getNextAccountCreationInfo());
-     EXPECT_EQ(accountInfo.index, 0);
-     accountInfo.publicKeys.push_back(hex::toByteArray(DEFAULT_HEX_PUB_KEY));
-
-     account = createCosmosLikeAccount(wallet, accountInfo.index, accountInfo);
- }
-
- std::shared_ptr<WalletPool> pool;
-};
-
-TEST_F(CosmosTransactionTest, BuildSignedSendTxForBroadcast) {
+TEST(CosmosTransactionTest, BuildSignedSendTxForBroadcast) {
     const std::string strTx = "{"
         "\"fee\":{\"amount\":[{\"amount\":\"5000\",\"denom\":\"uatom\"}],\"gas\":\"200000\"},"
         "\"memo\":\"Sent from Ledger\","
@@ -118,7 +81,7 @@ TEST_F(CosmosTransactionTest, BuildSignedSendTxForBroadcast) {
     EXPECT_EQ(tx->serializeForBroadcast(), expected);
 }
 
-TEST_F(CosmosTransactionTest, BuildDelegateTxForBroadcast) {
+TEST(CosmosTransactionTest, BuildDelegateTxForBroadcast) {
     const std::string strTx = "{"
         "\"fee\":{\"amount\":[{\"amount\":\"5000\",\"denom\":\"uatom\"}],\"gas\":\"200000\"},"
         "\"memo\":\"Sent from Ledger\","
@@ -144,7 +107,7 @@ TEST_F(CosmosTransactionTest, BuildDelegateTxForBroadcast) {
     EXPECT_EQ(tx->serializeForBroadcast(), expected);
 }
 
-TEST_F(CosmosTransactionTest, BuildUndelegateTxForBroadcast) {
+TEST(CosmosTransactionTest, BuildUndelegateTxForBroadcast) {
     const std::string strTx = "{"
         "\"fee\":{\"amount\":[{\"amount\":\"5000\",\"denom\":\"uatom\"}],\"gas\":\"200000\"},"
         "\"memo\":\"Sent from Ledger\","
@@ -170,7 +133,7 @@ TEST_F(CosmosTransactionTest, BuildUndelegateTxForBroadcast) {
     EXPECT_EQ(tx->serializeForBroadcast(), expected);
 }
 
-TEST_F(CosmosTransactionTest, BuildBeginRedelegateTxForBroadcast) {
+TEST(CosmosTransactionTest, BuildBeginRedelegateTxForBroadcast) {
     const std::string strTx = "{"
         "\"fee\":{\"amount\":[{\"amount\":\"5000\",\"denom\":\"uatom\"}],\"gas\":\"200000\"},"
         "\"memo\":\"Sent from Ledger\","
@@ -198,7 +161,7 @@ TEST_F(CosmosTransactionTest, BuildBeginRedelegateTxForBroadcast) {
     EXPECT_EQ(tx->serializeForBroadcast(), expected);
 }
 
-TEST_F(CosmosTransactionTest, BuildSubmitProposalTxForBroadcast) {
+TEST(CosmosTransactionTest, BuildSubmitProposalTxForBroadcast) {
     const std::string strTx = "{"
         "\"fee\":{\"amount\":[{\"amount\":\"5000\",\"denom\":\"uatom\"}],\"gas\":\"200000\"},"
         "\"memo\":\"Sent from Ledger\","
@@ -229,7 +192,7 @@ TEST_F(CosmosTransactionTest, BuildSubmitProposalTxForBroadcast) {
     EXPECT_EQ(tx->serializeForBroadcast(), expected);
 }
 
-TEST_F(CosmosTransactionTest, BuildVoteTxForBroadcast) {
+TEST(CosmosTransactionTest, BuildVoteTxForBroadcast) {
     const std::string strTx = "{"
         "\"fee\":{\"amount\":[{\"amount\":\"5000\",\"denom\":\"uatom\"}],\"gas\":\"200000\"},"
         "\"memo\":\"Sent from Ledger\","
@@ -254,7 +217,7 @@ TEST_F(CosmosTransactionTest, BuildVoteTxForBroadcast) {
     EXPECT_EQ(tx->serializeForBroadcast(), expected);
 }
 
-TEST_F(CosmosTransactionTest, BuildDepositTxForBroadcast) {
+TEST(CosmosTransactionTest, BuildDepositTxForBroadcast) {
     const std::string strTx = "{"
         "\"fee\":{\"amount\":[{\"amount\":\"5000\",\"denom\":\"uatom\"}],\"gas\":\"200000\"},"
         "\"memo\":\"Sent from Ledger\","
@@ -281,7 +244,7 @@ TEST_F(CosmosTransactionTest, BuildDepositTxForBroadcast) {
     EXPECT_EQ(tx->serializeForBroadcast(), expected);
 }
 
-TEST_F(CosmosTransactionTest, BuildWithdrawDelegationRewardTxForBroadcast) {
+TEST(CosmosTransactionTest, BuildWithdrawDelegationRewardTxForBroadcast) {
     const std::string strTx = "{"
         "\"fee\":{\"amount\":[{\"amount\":\"5000\",\"denom\":\"uatom\"}],\"gas\":\"200000\"},"
         "\"memo\":\"Sent from Ledger\","
@@ -305,7 +268,7 @@ TEST_F(CosmosTransactionTest, BuildWithdrawDelegationRewardTxForBroadcast) {
 }
 
 
-TEST_F(CosmosTransactionTest, BuildMultiSendTxForBroadcast) {
+TEST(CosmosTransactionTest, BuildMultiSendTxForBroadcast) {
     // From cosmos/cosmos-sdk tests :
     // https://github.com/cosmos/cosmos-sdk/blob/ebbfaf2a47d3e97a4720f643ca21d5a41676cdc0/x/bank/types/msgs_test.go#L217-L229
     const std::string strTx = "{"
@@ -338,7 +301,7 @@ TEST_F(CosmosTransactionTest, BuildMultiSendTxForBroadcast) {
     EXPECT_EQ(tx->serializeForBroadcast(), expected);
 }
 
-TEST_F(CosmosTransactionTest, BuildCreateValidatorTxForBroadcast) {
+TEST(CosmosTransactionTest, BuildCreateValidatorTxForBroadcast) {
     // TODO : find a transaction in Explorer to confirm the format here
     // For the time being we're using protobuf from cosmos-sdk as source :
     // https://github.com/cosmos/cosmos-sdk/blob/53bf2271d5bac054a8f74723732f21055c1b72d4/x/staking/types/types.pb.go
@@ -381,7 +344,7 @@ TEST_F(CosmosTransactionTest, BuildCreateValidatorTxForBroadcast) {
     EXPECT_EQ(tx->serializeForBroadcast(), expected);
 }
 
-TEST_F(CosmosTransactionTest, BuildEditValidatorTxForBroadcast) {
+TEST(CosmosTransactionTest, BuildEditValidatorTxForBroadcast) {
     // TODO : find a transaction in Explorer to confirm the format here
     // For the time being we're using protobuf from cosmos-sdk as source :
     // https://github.com/cosmos/cosmos-sdk/blob/53bf2271d5bac054a8f74723732f21055c1b72d4/x/staking/types/types.pb.go
@@ -420,7 +383,7 @@ TEST_F(CosmosTransactionTest, BuildEditValidatorTxForBroadcast) {
     EXPECT_EQ(tx->serializeForBroadcast(), expected);
 }
 
-TEST_F(CosmosTransactionTest, BuildSetWithdrawAddressTxForBroadcast) {
+TEST(CosmosTransactionTest, BuildSetWithdrawAddressTxForBroadcast) {
     // TODO : find a transaction in Explorer to confirm the format here
     const std::string strTx = "{"
         "\"fee\":{\"amount\":[{\"amount\":\"5001\",\"denom\":\"uatom\"}],\"gas\":\"200020\"},"
@@ -444,7 +407,7 @@ TEST_F(CosmosTransactionTest, BuildSetWithdrawAddressTxForBroadcast) {
     EXPECT_EQ(tx->serializeForBroadcast(), expected);
 }
 
-TEST_F(CosmosTransactionTest, BuildWithdrawDelegatorRewardsTxForBroadcast) {
+TEST(CosmosTransactionTest, BuildWithdrawDelegatorRewardsTxForBroadcast) {
     // TODO : find a transaction in Explorer to confirm the format here
     const std::string strTx = "{"
         "\"fee\":{\"amount\":[{\"amount\":\"5001\",\"denom\":\"uatom\"}],\"gas\":\"200020\"},"
@@ -468,7 +431,7 @@ TEST_F(CosmosTransactionTest, BuildWithdrawDelegatorRewardsTxForBroadcast) {
     EXPECT_EQ(tx->serializeForBroadcast(), expected);
 }
 
-TEST_F(CosmosTransactionTest, BuildWithdrawValidatorCommissionTxForBroadcast) {
+TEST(CosmosTransactionTest, BuildWithdrawValidatorCommissionTxForBroadcast) {
     // TODO : find a transaction in Explorer to confirm the format here
     const std::string strTx = "{"
         "\"fee\":{\"amount\":[{\"amount\":\"5001\",\"denom\":\"uatom\"}],\"gas\":\"200020\"},"
@@ -489,7 +452,7 @@ TEST_F(CosmosTransactionTest, BuildWithdrawValidatorCommissionTxForBroadcast) {
     EXPECT_EQ(tx->serializeForBroadcast(), expected);
 }
 
-TEST_F(CosmosTransactionTest, BuildUnjailTxForBroadcast) {
+TEST(CosmosTransactionTest, BuildUnjailTxForBroadcast) {
     // TODO : find a transaction in Explorer to confirm the format here
     const std::string strTx = "{"
         "\"fee\":{\"amount\":[{\"amount\":\"5001\",\"denom\":\"uatom\"}],\"gas\":\"200020\"},"
@@ -510,7 +473,7 @@ TEST_F(CosmosTransactionTest, BuildUnjailTxForBroadcast) {
     EXPECT_EQ(tx->serializeForBroadcast(), expected);
 }
 
-TEST_F(CosmosTransactionTest, BuildSendTxForSignature) {
+TEST(CosmosTransactionTest, BuildSendTxForSignature) {
     const std::string strTx = "{"
         "\"account_number\":\"6571\","
         "\"chain_id\":\"cosmoshub-3\","

--- a/core/test/cosmos/transactions_test.cpp
+++ b/core/test/cosmos/transactions_test.cpp
@@ -108,28 +108,8 @@ TEST_F(CosmosTransactionTest, BuildSignedSendTxForBroadcast) {
     // ensure the values are correct
     EXPECT_EQ(tx->getFee()->toLong(), 5000L);
     EXPECT_EQ(tx->getGas()->toLong(), 200000L);
-    EXPECT_EQ(sendMessage.fromAddress, "cosmos102hty0jv2s29lyc4u0tv97z9v298e24t3vwtpl");
-    EXPECT_EQ(sendMessage.toAddress, "cosmosvaloper1grgelyng2v6v3t8z87wu3sxgt9m5s03xfytvz7");
-    EXPECT_EQ(sendMessage.amount.size(), 1);
-    EXPECT_EQ(sendMessage.amount.front().amount, "1000000");
-    EXPECT_EQ(sendMessage.amount.front().denom, "uatom");
-
-    const std::string expected = "{\"mode\":\"async\",\"tx\":" + strTx + "}";
-    EXPECT_EQ(tx->serializeForBroadcast(), expected);
-}
-
-TEST_F(CosmosTransactionTest, EncodeToJSON) {
-    const auto strTx = "{\"account_number\":\"6571\",\"chain_id\":\"cosmoshub-3\",\"fee\":{\"amount\":[{\"amount\":\"5000\",\"denom\":\"uatom\"}],\"gas\":\"200000\"},\"memo\":\"Sent from Ledger\",\"msgs\":[{\"type\":\"cosmos-sdk/MsgSend\",\"value\":{\"amount\":[{\"amount\":\"1000000\",\"denom\":\"uatom\"}],\"from_address\":\"cosmos102hty0jv2s29lyc4u0tv97z9v298e24t3vwtpl\",\"to_address\":\"cosmosvaloper1grgelyng2v6v3t8z87wu3sxgt9m5s03xfytvz7\"}}],\"sequence\":\"0\"}";
-    const auto tx = api::CosmosLikeTransactionBuilder::parseRawSignedTransaction(currencies::ATOM, strTx);
-
-    auto message = tx->getMessages().front();
-    auto sendMessage = api::CosmosLikeMessage::unwrapMsgSend(message);
-
-    // ensure the values are correct
-    EXPECT_EQ(tx->getFee()->toLong(), 5000L);
-    EXPECT_EQ(tx->getGas()->toLong(), 200000L);
-    EXPECT_EQ(sendMessage.fromAddress, "cosmos102hty0jv2s29lyc4u0tv97z9v298e24t3vwtpl");
-    EXPECT_EQ(sendMessage.toAddress, "cosmosvaloper1grgelyng2v6v3t8z87wu3sxgt9m5s03xfytvz7");
+    EXPECT_EQ(sendMessage.fromAddress, "cosmos1d9h8qat57ljhcm");
+    EXPECT_EQ(sendMessage.toAddress, "cosmos1da6hgur4wsmpnjyg");
     EXPECT_EQ(sendMessage.amount.size(), 1);
     EXPECT_EQ(sendMessage.amount.front().amount, "1000000");
     EXPECT_EQ(sendMessage.amount.front().denom, "uatom");

--- a/core/test/cosmos/transactions_test.cpp
+++ b/core/test/cosmos/transactions_test.cpp
@@ -49,7 +49,41 @@
 using namespace ledger::testing::cosmos;
 using namespace ledger::core;
 
-class CosmosTransactionTest : public BaseFixture {};
+class CosmosTransactionTest : public BaseFixture {
+public:
+ void SetUp() override
+ {
+     BaseFixture::SetUp();
+#ifdef PG_SUPPORT
+     const bool usePostgreSQL = true;
+     auto poolConfig = DynamicObject::newInstance();
+     poolConfig->putString(api::PoolConfiguration::DATABASE_NAME, "postgres://localhost:5432/test_db");
+     pool = newDefaultPool("postgres", "", poolConfig, usePostgreSQL);
+#else
+     pool = newDefaultPool();
+#endif
+     backend->enableQueryLogging(true);
+ }
+
+ void setupTest(std::shared_ptr<CosmosLikeAccount> &account,
+                std::shared_ptr<CosmosLikeWallet> &wallet)
+ {
+     auto configuration = DynamicObject::newInstance();
+     configuration->putString(
+         api::Configuration::KEYCHAIN_DERIVATION_SCHEME,
+         "44'/<coin_type>'/<account>'/<node>/<address>");
+     wallet = std::dynamic_pointer_cast<CosmosLikeWallet>(
+         wait(pool->createWallet("e847815f-488a-4301-b67c-378a5e9c8a61", "atom", configuration)));
+
+     auto accountInfo = wait(wallet->getNextAccountCreationInfo());
+     EXPECT_EQ(accountInfo.index, 0);
+     accountInfo.publicKeys.push_back(hex::toByteArray(DEFAULT_HEX_PUB_KEY));
+
+     account = createCosmosLikeAccount(wallet, accountInfo.index, accountInfo);
+ }
+
+ std::shared_ptr<WalletPool> pool;
+};
 
 TEST_F(CosmosTransactionTest, BuildSignedSendTxForBroadcast) {
     const std::string strTx = "{"
@@ -66,6 +100,26 @@ TEST_F(CosmosTransactionTest, BuildSignedSendTxForBroadcast) {
             "\"pub_key\":{\"type\":\"tendermint/PubKeySecp256k1\",\"value\":\"AsS+z2hDho2VVupD1GUYtRoTyxpIzWwFohwCnqQjH83k\"},"
             "\"signature\":\"9Nn7Az62vDLW0bMgdcO26kzOeVrtd/M0GxXFsePghch7lY098oi6/MFnr0zKoeyoPxLUjCISn6JRvpVJ22WmBg==\""
         "}]}";
+    const auto tx = api::CosmosLikeTransactionBuilder::parseRawSignedTransaction(currencies::ATOM, strTx);
+
+    auto message = tx->getMessages().front();
+    auto sendMessage = api::CosmosLikeMessage::unwrapMsgSend(message);
+
+    // ensure the values are correct
+    EXPECT_EQ(tx->getFee()->toLong(), 5000L);
+    EXPECT_EQ(tx->getGas()->toLong(), 200000L);
+    EXPECT_EQ(sendMessage.fromAddress, "cosmos102hty0jv2s29lyc4u0tv97z9v298e24t3vwtpl");
+    EXPECT_EQ(sendMessage.toAddress, "cosmosvaloper1grgelyng2v6v3t8z87wu3sxgt9m5s03xfytvz7");
+    EXPECT_EQ(sendMessage.amount.size(), 1);
+    EXPECT_EQ(sendMessage.amount.front().amount, "1000000");
+    EXPECT_EQ(sendMessage.amount.front().denom, "uatom");
+
+    const std::string expected = "{\"mode\":\"async\",\"tx\":" + strTx + "}";
+    EXPECT_EQ(tx->serializeForBroadcast(), expected);
+}
+
+TEST_F(CosmosTransactionTest, EncodeToJSON) {
+    const auto strTx = "{\"account_number\":\"6571\",\"chain_id\":\"cosmoshub-3\",\"fee\":{\"amount\":[{\"amount\":\"5000\",\"denom\":\"uatom\"}],\"gas\":\"200000\"},\"memo\":\"Sent from Ledger\",\"msgs\":[{\"type\":\"cosmos-sdk/MsgSend\",\"value\":{\"amount\":[{\"amount\":\"1000000\",\"denom\":\"uatom\"}],\"from_address\":\"cosmos102hty0jv2s29lyc4u0tv97z9v298e24t3vwtpl\",\"to_address\":\"cosmosvaloper1grgelyng2v6v3t8z87wu3sxgt9m5s03xfytvz7\"}}],\"sequence\":\"0\"}";
     const auto tx = api::CosmosLikeTransactionBuilder::parseRawSignedTransaction(currencies::ATOM, strTx);
 
     auto message = tx->getMessages().front();

--- a/core/test/integration/BaseFixture.h
+++ b/core/test/integration/BaseFixture.h
@@ -94,8 +94,8 @@ extern const std::string TX_4;
 
 class BaseFixture : public ::testing::Test {
 public:
-    void SetUp() override;
-    void TearDown() override;
+    virtual void SetUp() override;
+    virtual void TearDown() override;
     std::shared_ptr<WalletPool> newDefaultPool(const std::string &poolName = "my_ppol",
                                                const std::string &password = "test",
                                                const std::shared_ptr<api::DynamicObject> &configuration = api::DynamicObject::newInstance(),

--- a/core/test/integration/synchronization/cosmos_synchronization.cpp
+++ b/core/test/integration/synchronization/cosmos_synchronization.cpp
@@ -347,7 +347,6 @@ TEST_F(CosmosLikeWalletSynchronization, Balances)
     std::string hexPubKey =
         "0388459b2653519948b12492f1a0b464720110c147a8155d23d423a5cc3c21d89a";  // Obelix
 
-    std::shared_ptr<CosmosLikeAccount> account;
     std::shared_ptr<AbstractWallet> wallet;
     std::shared_ptr<CosmosLikeAccount> account;
 


### PR DESCRIPTION
 - Migrations are not postgres-ready

 - asio is still choosing the wrong string_view branch when compiling the "release" jobs in linux at least

 - Bad warning in AbstractAddress : /root/lib-ledger-core/core/src/wallet/common/AbstractAddress.cpp:64:21: warning: enumeration value 'COSMOS' not handled in switch [-Wswitch]
                switch (currency.walletType) {