### PR TITLE
[COIN 275] Get account sequence and number from CosmosLikeAccount

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,7 +138,7 @@ jobs:
             command: |
                 cd ../lib-ledger-core-build
 
-                ~/cmake-3.16.5-Linux-x86_64/bin/ctest -VV -timeout 60
+                ~/cmake-3.16.5-Linux-x86_64/bin/ctest -VV -timeout 120
   build_macos_release:
     macos:
       xcode: "10.0.0"
@@ -232,7 +232,7 @@ jobs:
           name: Run_Tests
           command: |
               cd ../lib-ledger-core-build
-              ctest -VV -timeout 60
+              ctest -VV -timeout 120
   publish_jar:
     macos:
       xcode: "10.0.0"

--- a/core/idl/wallet/cosmos/wallet.djinni
+++ b/core/idl/wallet/cosmos/wallet.djinni
@@ -117,6 +117,14 @@ CosmosLikeAccount = interface +c {
 
         getDelegations(callback: ListCallback<CosmosLikeDelegation>);
         getPendingRewards(callback: ListCallback<CosmosLikeReward>);
+
+        # Get the current account sequence (synchronize to get latest value)
+        # string like "14"
+        getSequence(): string;
+
+        # Get the account number
+        # String like "15"
+        getAccountNumber(): string;
 }
 
 #Class representing a Cosmos delegation

--- a/core/src/api/CosmosLikeAccount.hpp
+++ b/core/src/api/CosmosLikeAccount.hpp
@@ -64,6 +64,18 @@ public:
     virtual void getDelegations(const std::shared_ptr<CosmosLikeDelegationListCallback> & callback) = 0;
 
     virtual void getPendingRewards(const std::shared_ptr<CosmosLikeRewardListCallback> & callback) = 0;
+
+    /**
+     * Get the current account sequence (synchronize to get latest value)
+     * string like "14"
+     */
+    virtual std::string getSequence() = 0;
+
+    /**
+     * Get the account number
+     * String like "15"
+     */
+    virtual std::string getAccountNumber() = 0;
 };
 
 } } }  // namespace ledger::core::api

--- a/core/src/jni/jni/CosmosLikeAccount.cpp
+++ b/core/src/jni/jni/CosmosLikeAccount.cpp
@@ -150,4 +150,24 @@ CJNIEXPORT void JNICALL Java_co_ledger_core_CosmosLikeAccount_00024CppProxy_nati
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, )
 }
 
+CJNIEXPORT jstring JNICALL Java_co_ledger_core_CosmosLikeAccount_00024CppProxy_native_1getSequence(JNIEnv* jniEnv, jobject /*this*/, jlong nativeRef)
+{
+    try {
+        DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
+        const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::CosmosLikeAccount>(nativeRef);
+        auto r = ref->getSequence();
+        return ::djinni::release(::djinni::String::fromCpp(jniEnv, r));
+    } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
+}
+
+CJNIEXPORT jstring JNICALL Java_co_ledger_core_CosmosLikeAccount_00024CppProxy_native_1getAccountNumber(JNIEnv* jniEnv, jobject /*this*/, jlong nativeRef)
+{
+    try {
+        DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
+        const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::CosmosLikeAccount>(nativeRef);
+        auto r = ref->getAccountNumber();
+        return ::djinni::release(::djinni::String::fromCpp(jniEnv, r));
+    } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
+}
+
 }  // namespace djinni_generated

--- a/core/src/wallet/cosmos/CosmosLikeAccount.cpp
+++ b/core/src/wallet/cosmos/CosmosLikeAccount.cpp
@@ -617,7 +617,7 @@ namespace ledger {
                                 tx->setGas(request.gas);
                                 tx->setMemo(request.memo);
                                 tx->setMessages(request.messages);
-                                tx->setSequence(self->getSequence());
+                                tx->setSequence(request.sequence.empty() ? self->getSequence() : request.sequence);
                                 tx->setSigningPubKey(self->getKeychain()->getPublicKey());
                                 return Future<std::shared_ptr<api::CosmosLikeTransaction>>::successful(tx);
                         };

--- a/core/src/wallet/cosmos/CosmosLikeAccount.cpp
+++ b/core/src/wallet/cosmos/CosmosLikeAccount.cpp
@@ -473,12 +473,34 @@ namespace ledger {
                                                                 });
 
                         // Update account level data (sequence, accountnumber...)
+                        // HACK : forcefully overwrite the current account address.
+                        // An account with 0 transaction can have an empty
+                        // address field in the received accountData.
+                        // Therefore we store the address and force it
+                        // back to the old value
+                        // Example result from Gaia explorer :
+                        // base_url/auth/accounts/{address} with a valid, 0 transaction address :
+                        // {
+                        //  "height": "1296656",
+                        //  "result": {
+                        //    "type": "cosmos-sdk/Account",
+                        //    "value": {
+                        //      "address": "",
+                        //      "coins": [],
+                        //      "public_key": null,
+                        //      "account_number": "0",
+                        //      "sequence": "0"
+                        //    }
+                        //  }
+                        //}
+                        const auto savedAddress = _accountData->address;
                         _explorer->getAccount(_accountData->address)
                             .onComplete(
                                 getContext(),
-                                [self](const TryPtr<cosmos::Account> &accountData) mutable {
+                                [self, savedAddress](const TryPtr<cosmos::Account> &accountData) mutable {
                                     if (accountData.isSuccess()) {
                                         self->_accountData = accountData.getValue();
+                                        self->_accountData->address = savedAddress;
                                     }
                                 });
 

--- a/core/src/wallet/cosmos/CosmosLikeAccount.cpp
+++ b/core/src/wallet/cosmos/CosmosLikeAccount.cpp
@@ -590,8 +590,7 @@ namespace ledger {
 
                 std::string CosmosLikeAccount::getSequence()
                 {
-                    // Assuming _accountData is only valid if accountNumber has been fetched
-                    if (!_accountData || _accountData->accountNumber.empty()) {
+                    if (!_accountData) {
                         throw make_exception(
                             api::ErrorCode::ILLEGAL_STATE, "account must be synchronized first");
                     }
@@ -600,8 +599,7 @@ namespace ledger {
 
                 std::string CosmosLikeAccount::getAccountNumber()
                 {
-                    // Assuming _accountData is only valid if accountNumber has been fetched
-                    if (!_accountData || _accountData->accountNumber.empty()) {
+                    if (!_accountData) {
                         throw make_exception(
                             api::ErrorCode::ILLEGAL_STATE, "account must be synchronized first");
                     }

--- a/core/src/wallet/cosmos/CosmosLikeAccount.cpp
+++ b/core/src/wallet/cosmos/CosmosLikeAccount.cpp
@@ -287,67 +287,8 @@ namespace ledger {
                                         CosmosLikeOperationDatabaseHelper::updateOperation(sql, operation.uid, msg.uid);
                                         emitNewOperationEvent(operation);
                                 }
+                                result = static_cast<int>(operation.type);
                        }
-
-
-//
-//             for (const auto& msg : tx.messages) {
-//                 operation.senders = {msg.sender};
-//                 operation.recipients = {msg.recipient};
-//                 operation.amount = msg.amount;
-//                 operation.fees = Option<BigInt>(msg.fees);
-//
-//                 if (msg.sender == address) {
-//                     // Do the send operation
-//                     operation.type = api::OperationType::SEND;
-//                     operation.refreshUid();
-//                     if (OperationDatabaseHelper::putOperation(sql, operation)) {
-//                         emitNewOperationEvent(operation);
-//                     }
-//                     result = static_cast<int>(operation.type);
-//                 }
-//
-//                 if (msg.recipient == address) {
-//                     // Do the receive operation
-//                     operation.type = api::OperationType::RECEIVE;
-//                     operation.refreshUid();
-//                     if (OperationDatabaseHelper::putOperation(sql, operation)) {
-//                         emitNewOperationEvent(operation);
-//                     }
-//                     result = static_cast<int>(operation.type);
-//                 }
-//
-//             }
-
-                        // Operation operation;
-                        // inflateOperation(operation, wallet, transaction);
-                        // std::vector<std::string> senders{transaction.sender};
-                        // operation.senders = std::move(senders);
-                        // std::vector<std::string> receivers{transaction.receiver};
-                        // operation.recipients = std::move(receivers);
-                        // operation.fees = transaction.gasLimit * transaction.gasPrice;
-                        // operation.trust = std::make_shared<TrustIndicator>();
-                        // operation.date = transaction.receivedAt;
-
-                        // if (_accountData->address == transaction.sender) {
-                        //     operation.amount = transaction.value;
-                        //     operation.type = api::OperationType::SEND;
-                        //     operation.refreshUid();
-                        //     if (OperationDatabaseHelper::putOperation(sql, operation)) {
-                        //         emitNewOperationEvent(operation);
-                        //     }
-                        //     result = static_cast<int>(operation.type);
-                        // }
-
-                        // if (_accountData->address == transaction.receiver) {
-                        //     operation.amount = transaction.value;
-                        //     operation.type = api::OperationType::RECEIVE;
-                        //     operation.refreshUid();
-                        //     if (OperationDatabaseHelper::putOperation(sql, operation)) {
-                        //         emitNewOperationEvent(operation);
-                        //     }
-                        //     result = static_cast<int>(operation.type);
-                        // }
 
                         return result;
                 }

--- a/core/src/wallet/cosmos/CosmosLikeAccount.hpp
+++ b/core/src/wallet/cosmos/CosmosLikeAccount.hpp
@@ -154,9 +154,8 @@ namespace ledger {
                         private:
                                 std::shared_ptr<CosmosLikeAccount> getSelf();
 
-                                std::shared_ptr<cosmos::Account> _accData;
+                                std::shared_ptr<cosmos::Account> _accountData;
                                 std::shared_ptr<CosmosLikeKeychain> _keychain;
-                                std::string _accountAddress;
                                 std::shared_ptr<CosmosLikeBlockchainExplorer> _explorer;
                                 std::shared_ptr<CosmosLikeAccountSynchronizer> _synchronizer;
                                 std::shared_ptr<CosmosLikeBlockchainObserver> _observer;

--- a/core/src/wallet/cosmos/CosmosLikeAccount.hpp
+++ b/core/src/wallet/cosmos/CosmosLikeAccount.hpp
@@ -120,6 +120,10 @@ namespace ledger {
 
                                 void getEstimatedGasLimit(const std::shared_ptr<api::CosmosLikeTransaction> &transaction, const std::shared_ptr<api::BigIntCallback> &callback) override;
 
+                                // Account related data
+                                std::string getSequence() override;
+                                std::string getAccountNumber() override;
+
                                 // Balances
                                 FuturePtr<Amount> getTotalBalance() const;
                                 void getTotalBalance(const std::shared_ptr<api::AmountCallback> &callback) override;
@@ -150,6 +154,7 @@ namespace ledger {
                         private:
                                 std::shared_ptr<CosmosLikeAccount> getSelf();
 
+                                std::shared_ptr<cosmos::Account> _accData;
                                 std::shared_ptr<CosmosLikeKeychain> _keychain;
                                 std::string _accountAddress;
                                 std::shared_ptr<CosmosLikeBlockchainExplorer> _explorer;

--- a/core/src/wallet/cosmos/explorers/CosmosLikeBlockchainExplorer.hpp
+++ b/core/src/wallet/cosmos/explorers/CosmosLikeBlockchainExplorer.hpp
@@ -78,9 +78,8 @@ namespace ledger {
             virtual FuturePtr<cosmos::Block> getCurrentBlock() const = 0;
             virtual FuturePtr<cosmos::Block> getCurrentBlock() = 0;
             virtual FuturePtr<cosmos::Block> getBlock(uint64_t& blockHeight) = 0;
-            virtual FuturePtr<cosmos::Account> getAccount(const std::string& account) = 0;
+            virtual FuturePtr<cosmos::Account> getAccount(const std::string& account) const  = 0;
             virtual const std::vector<TransactionFilter>& getTransactionFilters() = 0;
-
 
             // Balances
             /// Get Total Balance

--- a/core/src/wallet/cosmos/explorers/GaiaCosmosLikeBlockchainExplorer.cpp
+++ b/core/src/wallet/cosmos/explorers/GaiaCosmosLikeBlockchainExplorer.cpp
@@ -108,7 +108,7 @@ namespace ledger {
         }
 
         FuturePtr<ledger::core::cosmos::Account>
-        GaiaCosmosLikeBlockchainExplorer::getAccount(const std::string &account) {
+        GaiaCosmosLikeBlockchainExplorer::getAccount(const std::string &account) const {
             return _http->GET(fmt::format("/auth/accounts/{}", account), ACCEPT_HEADER)
                 .json(true)
                 .mapPtr<cosmos::Account>(getContext(), [] (const HttpRequest::JsonResult& response) {

--- a/core/src/wallet/cosmos/explorers/GaiaCosmosLikeBlockchainExplorer.hpp
+++ b/core/src/wallet/cosmos/explorers/GaiaCosmosLikeBlockchainExplorer.hpp
@@ -69,7 +69,7 @@ namespace ledger {
             FuturePtr<cosmos::Block> getBlock(uint64_t &blockHeight) override;
 
             // Account querier
-            FuturePtr<ledger::core::cosmos::Account> getAccount(const std::string &account) override;
+            FuturePtr<ledger::core::cosmos::Account> getAccount(const std::string &account) const override;
 
             // CurrentBlock querier
             FuturePtr<cosmos::Block> getCurrentBlock() override;

--- a/core/test/cosmos/db_test.cpp
+++ b/core/test/cosmos/db_test.cpp
@@ -35,14 +35,15 @@ public:
  void setupTest(
      std::shared_ptr<WalletPool> &pool,
      std::shared_ptr<CosmosLikeAccount> &account,
-     std::shared_ptr<CosmosLikeWallet> &wallet)
+     std::shared_ptr<CosmosLikeWallet> &wallet,
+     const std::string& walletName)
  {
      auto configuration = DynamicObject::newInstance();
      configuration->putString(
          api::Configuration::KEYCHAIN_DERIVATION_SCHEME,
          "44'/<coin_type>'/<account>'/<node>/<address>");
      wallet = std::dynamic_pointer_cast<CosmosLikeWallet>(
-         wait(pool->createWallet("e847815f-488a-4301-b67c-378a5e9c8a61", "atom", configuration)));
+         wait(pool->createWallet(walletName, "atom", configuration)));
 
      auto accountInfo = wait(wallet->getNextAccountCreationInfo());
      EXPECT_EQ(accountInfo.index, 0);
@@ -62,7 +63,7 @@ public:
 TEST_F(CosmosDBTest, BasicDBTest) {
     std::shared_ptr<CosmosLikeAccount> account;
     std::shared_ptr<CosmosLikeWallet> wallet;
-    setupTest(pool, account, wallet);
+    setupTest(pool, account, wallet, "90673bef-38d3-4a09-ad7c-f67dc4370210");
 
     std::chrono::system_clock::time_point timeRef = DateUtils::now();
 
@@ -99,7 +100,7 @@ TEST_F(CosmosDBTest, BasicDBTest) {
 TEST_F(CosmosDBTest, OperationQueryTest) {
     std::shared_ptr<CosmosLikeAccount> account;
     std::shared_ptr<CosmosLikeWallet> wallet;
-    setupTest(pool, account, wallet);
+    setupTest(pool, account, wallet, "38660eb1-2f89-4096-a8d5-fcaca0c44428");
 
     std::chrono::system_clock::time_point timeRef = DateUtils::now();
 
@@ -146,7 +147,7 @@ TEST_F(CosmosDBTest, OperationQueryTest) {
 TEST_F(CosmosDBTest, UnsuportedMsgTypeTest) {
     std::shared_ptr<CosmosLikeAccount> account;
     std::shared_ptr<CosmosLikeWallet> wallet;
-    setupTest(pool, account, wallet);
+    setupTest(pool, account, wallet, "f727a3d9-7e98-4bbf-b92c-c3976483ac89");
 
     std::chrono::system_clock::time_point timeRef = DateUtils::now();
 
@@ -178,7 +179,7 @@ TEST_F(CosmosDBTest, UnsuportedMsgTypeTest) {
 TEST_F(CosmosDBTest, MultipleMsgTest) {
     std::shared_ptr<CosmosLikeAccount> account;
     std::shared_ptr<CosmosLikeWallet> wallet;
-    setupTest(pool, account, wallet);
+    setupTest(pool, account, wallet, "ee64142f-a695-4755-9eb1-6c5a2a2291c3");
 
     std::chrono::system_clock::time_point timeRef = DateUtils::now();
 

--- a/core/test/integration/synchronization/cosmos_synchronization.cpp
+++ b/core/test/integration/synchronization/cosmos_synchronization.cpp
@@ -338,6 +338,13 @@ TEST_F(CosmosLikeWalletSynchronization, MediumXpubSynchronization) {
             auto ops = wait(std::dynamic_pointer_cast<OperationQuery>(account->queryOperations()->complete())->execute());
             fmt::print("Ops: {}\n", ops.size());
             EXPECT_GT(ops.size(), 0);
+
+            const auto sequenceNumber = account->getSequence();
+            const int sequence = std::atoi(sequenceNumber.c_str());
+            EXPECT_GE(sequence, 1226) << "Sequence was at 1226 on 2020-03-26";
+
+            const auto accountNumber = account->getAccountNumber();
+            EXPECT_EQ(accountNumber, "12850");
         }
     }
 }

--- a/core/test/integration/synchronization/cosmos_synchronization.cpp
+++ b/core/test/integration/synchronization/cosmos_synchronization.cpp
@@ -277,7 +277,7 @@ TEST_F(CosmosLikeWalletSynchronization, GetCurrentBlockWithExplorer) {
 }
 
 TEST_F(CosmosLikeWalletSynchronization, MediumXpubSynchronization) {
-    auto walletName = "e847815f-488a-4301-b67c-378a5e9c8a61";
+    auto walletName = "8d99cc44-9061-43a4-9edd-f938d2007926";
 #ifdef PG_SUPPORT
     const bool usePostgreSQL = true;
     auto poolConfig = DynamicObject::newInstance();


### PR DESCRIPTION
The `cosmos::Account` data structure wasn't stored in the implementation class `core::CosmosLikeAccount`. The data structure has been added and is updated on each synchronization using the existing explorer method.

Tests have been added on `MediumXpubSynchronization`