### PR TITLE
Send transaction from CLI

### DIFF
--- a/core/idl/wallet/cosmos/wallet.djinni
+++ b/core/idl/wallet/cosmos/wallet.djinni
@@ -66,6 +66,10 @@ CosmosLikeTransactionBuilder = interface +c {
         # @param sequence The sequence to set
         setSequence(sequence: string): CosmosLikeTransactionBuilder;
 
+        # Set accountNumber
+        # @param accountNumber The accountNumber to set
+        setAccountNumber(accountNumber: string): CosmosLikeTransactionBuilder;
+
         # Add a new message in the internal range of messages
         # @param msg a new message
         addMessage(msg: CosmosLikeMessage): CosmosLikeTransactionBuilder;
@@ -120,11 +124,11 @@ CosmosLikeAccount = interface +c {
 
         # Get the current account sequence (synchronize to get latest value)
         # string like "14"
-        getSequence(): string;
+        getSequence(callback: Callback<string>);
 
         # Get the account number
         # String like "15"
-        getAccountNumber(): string;
+        getAccountNumber(callback: Callback<string>);
 }
 
 #Class representing a Cosmos delegation

--- a/core/src/api/CosmosLikeAccount.hpp
+++ b/core/src/api/CosmosLikeAccount.hpp
@@ -69,13 +69,13 @@ public:
      * Get the current account sequence (synchronize to get latest value)
      * string like "14"
      */
-    virtual std::string getSequence() = 0;
+    virtual void getSequence(const std::shared_ptr<StringCallback> & callback) = 0;
 
     /**
      * Get the account number
      * String like "15"
      */
-    virtual std::string getAccountNumber() = 0;
+    virtual void getAccountNumber(const std::shared_ptr<StringCallback> & callback) = 0;
 };
 
 } } }  // namespace ledger::core::api

--- a/core/src/api/CosmosLikeTransactionBuilder.hpp
+++ b/core/src/api/CosmosLikeTransactionBuilder.hpp
@@ -39,6 +39,12 @@ public:
     virtual std::shared_ptr<CosmosLikeTransactionBuilder> setSequence(const std::string & sequence) = 0;
 
     /**
+     * Set accountNumber
+     * @param accountNumber The accountNumber to set
+     */
+    virtual std::shared_ptr<CosmosLikeTransactionBuilder> setAccountNumber(const std::string & accountNumber) = 0;
+
+    /**
      * Add a new message in the internal range of messages
      * @param msg a new message
      */

--- a/core/src/jni/jni/CosmosLikeAccount.cpp
+++ b/core/src/jni/jni/CosmosLikeAccount.cpp
@@ -150,24 +150,22 @@ CJNIEXPORT void JNICALL Java_co_ledger_core_CosmosLikeAccount_00024CppProxy_nati
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, )
 }
 
-CJNIEXPORT jstring JNICALL Java_co_ledger_core_CosmosLikeAccount_00024CppProxy_native_1getSequence(JNIEnv* jniEnv, jobject /*this*/, jlong nativeRef)
+CJNIEXPORT void JNICALL Java_co_ledger_core_CosmosLikeAccount_00024CppProxy_native_1getSequence(JNIEnv* jniEnv, jobject /*this*/, jlong nativeRef, jobject j_callback)
 {
     try {
         DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
         const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::CosmosLikeAccount>(nativeRef);
-        auto r = ref->getSequence();
-        return ::djinni::release(::djinni::String::fromCpp(jniEnv, r));
-    } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
+        ref->getSequence(::djinni_generated::StringCallback::toCpp(jniEnv, j_callback));
+    } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, )
 }
 
-CJNIEXPORT jstring JNICALL Java_co_ledger_core_CosmosLikeAccount_00024CppProxy_native_1getAccountNumber(JNIEnv* jniEnv, jobject /*this*/, jlong nativeRef)
+CJNIEXPORT void JNICALL Java_co_ledger_core_CosmosLikeAccount_00024CppProxy_native_1getAccountNumber(JNIEnv* jniEnv, jobject /*this*/, jlong nativeRef, jobject j_callback)
 {
     try {
         DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
         const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::CosmosLikeAccount>(nativeRef);
-        auto r = ref->getAccountNumber();
-        return ::djinni::release(::djinni::String::fromCpp(jniEnv, r));
-    } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
+        ref->getAccountNumber(::djinni_generated::StringCallback::toCpp(jniEnv, j_callback));
+    } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, )
 }
 
 }  // namespace djinni_generated

--- a/core/src/jni/jni/CosmosLikeTransactionBuilder.cpp
+++ b/core/src/jni/jni/CosmosLikeTransactionBuilder.cpp
@@ -44,6 +44,16 @@ CJNIEXPORT jobject JNICALL Java_co_ledger_core_CosmosLikeTransactionBuilder_0002
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
+CJNIEXPORT jobject JNICALL Java_co_ledger_core_CosmosLikeTransactionBuilder_00024CppProxy_native_1setAccountNumber(JNIEnv* jniEnv, jobject /*this*/, jlong nativeRef, jstring j_accountNumber)
+{
+    try {
+        DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
+        const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::CosmosLikeTransactionBuilder>(nativeRef);
+        auto r = ref->setAccountNumber(::djinni::String::toCpp(jniEnv, j_accountNumber));
+        return ::djinni::release(::djinni_generated::CosmosLikeTransactionBuilder::fromCpp(jniEnv, r));
+    } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
+}
+
 CJNIEXPORT jobject JNICALL Java_co_ledger_core_CosmosLikeTransactionBuilder_00024CppProxy_native_1addMessage(JNIEnv* jniEnv, jobject /*this*/, jlong nativeRef, jobject j_msg)
 {
     try {

--- a/core/src/wallet/cosmos/CosmosLikeAccount.cpp
+++ b/core/src/wallet/cosmos/CosmosLikeAccount.cpp
@@ -501,6 +501,16 @@ namespace ledger {
                                     if (accountData.isSuccess()) {
                                         self->_accountData = accountData.getValue();
                                         self->_accountData->address = savedAddress;
+                                        const CosmosLikeAccountDatabaseEntry update = {
+                                            0,  // unused in
+                                                 // CosmosLikeAccountDatabaseHelper::updateAccount
+                                             savedAddress,
+                                             *(self->_accountData),
+                                             std::chrono::system_clock::now()};
+                                        soci::session sql(
+                                            self->getWallet()->getDatabase()->getPool());
+                                        CosmosLikeAccountDatabaseHelper::updateAccount(
+                                            sql, self->getAccountUid(), update);
                                     }
                                 });
 
@@ -580,7 +590,7 @@ namespace ledger {
                                 tx->setGas(request.gas);
                                 tx->setMemo(request.memo);
                                 tx->setMessages(request.messages);
-                                tx->setSequence(request.sequence.empty() ? self->getSequence() : request.sequence);
+                                tx->setSequence(request.sequence.empty() ? std::to_string(std::stoi(self->getSequence()) + 1) : request.sequence);
                                 tx->setSigningPubKey(self->getKeychain()->getPublicKey());
                                 return Future<std::shared_ptr<api::CosmosLikeTransaction>>::successful(tx);
                         };

--- a/core/src/wallet/cosmos/CosmosLikeAccount.cpp
+++ b/core/src/wallet/cosmos/CosmosLikeAccount.cpp
@@ -84,7 +84,20 @@ namespace ledger {
                 }
 
                 std::shared_ptr<api::CosmosLikeAccount> CosmosLikeAccount::asCosmosLikeAccount() {
-                        return std::dynamic_pointer_cast<CosmosLikeAccount>(shared_from_this());
+                        auto account = std::dynamic_pointer_cast<CosmosLikeAccount>(shared_from_this());
+                        account->updateFromDb();
+                        return account;
+                }
+
+                void CosmosLikeAccount::updateFromDb()
+                {
+                    soci::session sql(this->getWallet()->getDatabase()->getPool());
+                    CosmosLikeAccountDatabaseEntry dbAccount;
+                    bool existingAccount = CosmosLikeAccountDatabaseHelper::queryAccount(
+                        sql, getAccountUid(), dbAccount);
+                    if (existingAccount) {
+                        *_accountData = dbAccount.details;
+                    }
                 }
 
                 static void computeAndSetTypeAmount(

--- a/core/src/wallet/cosmos/CosmosLikeAccount.hpp
+++ b/core/src/wallet/cosmos/CosmosLikeAccount.hpp
@@ -154,6 +154,7 @@ namespace ledger {
 
                         private:
                                 std::shared_ptr<CosmosLikeAccount> getSelf();
+                                void updateFromDb();
 
                                 std::shared_ptr<cosmos::Account> _accountData;
                                 std::shared_ptr<CosmosLikeKeychain> _keychain;

--- a/core/src/wallet/cosmos/CosmosLikeAccount.hpp
+++ b/core/src/wallet/cosmos/CosmosLikeAccount.hpp
@@ -121,8 +121,9 @@ namespace ledger {
                                 void getEstimatedGasLimit(const std::shared_ptr<api::CosmosLikeTransaction> &transaction, const std::shared_ptr<api::BigIntCallback> &callback) override;
 
                                 // Account related data
-                                std::string getSequence() override;
-                                std::string getAccountNumber() override;
+                                void getSequence(const std::shared_ptr<api::StringCallback>& callback) override;
+                                void getAccountNumber(const std::shared_ptr<api::StringCallback>& callback) override;
+                                cosmos::Account getInfo() const;
 
                                 // Balances
                                 FuturePtr<Amount> getTotalBalance() const;

--- a/core/src/wallet/cosmos/CosmosLikeWallet.cpp
+++ b/core/src/wallet/cosmos/CosmosLikeWallet.cpp
@@ -152,7 +152,6 @@ namespace ledger {
         }
 
         bool CosmosLikeWallet::hasMultipleAddresses() const {
-            // TODO check if ATOM accepts multiple addresses
             return false;
         }
 

--- a/core/src/wallet/cosmos/api_impl/CosmosLikeTransactionApi.cpp
+++ b/core/src/wallet/cosmos/api_impl/CosmosLikeTransactionApi.cpp
@@ -345,7 +345,7 @@ namespace ledger {
 
             // Set mode
             // TODO What mode do we want? (sync|async|block)
-            vString.SetString("async", static_cast<SizeType>(5), allocator);
+            vString.SetString("block", static_cast<SizeType>(5), allocator);
             document.AddMember(kMode, vString, allocator);
 
             StringBuffer buffer;

--- a/core/src/wallet/cosmos/database/CosmosLikeAccountDatabaseHelper.cpp
+++ b/core/src/wallet/cosmos/database/CosmosLikeAccountDatabaseHelper.cpp
@@ -98,7 +98,7 @@ namespace ledger {
                    "sequence = :sequence,"
                    "balances = :balances,"
                    "account_type = :account_type,"
-                   "last_update = :last_update,"
+                   "last_update = :last_update "
                    "WHERE uid = :uid",
                    use(entry.details.accountNumber),
                    use(entry.details.sequence),

--- a/core/src/wallet/cosmos/database/CosmosLikeAccountDatabaseHelper.cpp
+++ b/core/src/wallet/cosmos/database/CosmosLikeAccountDatabaseHelper.cpp
@@ -67,17 +67,24 @@ namespace ledger {
                                                "FROM cosmos_accounts "
                                                "WHERE uid = :uid", use(
                     accountUid));
+            const auto COL_IDX = 0;
+            const auto COL_ADDRESS = 1;
+            const auto COL_ACC_TYPE = 2;
+            const auto COL_ACC_NUM = 3;
+            const auto COL_SEQUENCE = 4;
+            const auto COL_BALANCES = 5;
+            const auto COL_LAST_UPDATE = 6;
             for (auto &row : rows) {
-                entry.index = row.get<int32_t>(0);
-                entry.address = row.get<std::string>(1);
-                auto accountType = row.get<Option<std::string>>(2);
-                auto accountNumber = row.get<Option<std::string>>(3);
-                auto sequence = row.get<Option<std::string>>(4);
-                auto balances = row.get<Option<std::string>>(5);
-                auto lastUpdate = row.get<Option<std::chrono::system_clock::time_point>>(6);
+                entry.index = row.get<int32_t>(COL_IDX);
+                entry.address = row.get<std::string>(COL_ADDRESS);
+                auto accountType = row.get<Option<std::string>>(COL_ACC_TYPE);
+                auto accountNumber = row.get<Option<std::string>>(COL_ACC_NUM);
+                auto sequence = row.get<Option<std::string>>(COL_SEQUENCE);
+                auto balances = row.get<Option<std::string>>(COL_BALANCES);
+                auto lastUpdate = row.get<Option<std::chrono::system_clock::time_point>>(COL_LAST_UPDATE);
 
                 entry.details.type = accountType.getValueOr("");
-                entry.details.sequence = accountType.getValueOr("0");
+                entry.details.sequence = sequence.getValueOr("0");
                 entry.details.accountNumber = accountNumber.getValueOr("0");
                 if (balances.nonEmpty()) {
                     soci::stringToCoins(balances.getValue(), entry.details.balances);

--- a/core/src/wallet/cosmos/explorers/GaiaCosmosLikeBlockchainExplorer.cpp
+++ b/core/src/wallet/cosmos/explorers/GaiaCosmosLikeBlockchainExplorer.cpp
@@ -285,8 +285,15 @@ namespace ledger {
 
             return _http->POST("/txs", transaction, headers)
                         .json().template map<String>(_executionContext, [] (const HttpRequest::JsonResult& result) -> String {
+                            // TODO : the content of this payload actually depends on the mode of the transaction
+                            // block has both check_tx and deliver_tx
+                            // sync has check_tx
+                            // async has nothing
                             auto& json = *std::get<1>(result);
-                            return json["result"].GetString();
+                            if (json.HasMember("raw_log")) {
+                                return json["raw_log"].GetString();
+                            }
+                            return "";
                         });
         }
 

--- a/core/src/wallet/cosmos/transaction_builders/CosmosLikeTransactionBuilder.cpp
+++ b/core/src/wallet/cosmos/transaction_builders/CosmosLikeTransactionBuilder.cpp
@@ -436,6 +436,11 @@ namespace ledger {
             return shared_from_this();
         }
 
+        std::shared_ptr<api::CosmosLikeTransactionBuilder>  CosmosLikeTransactionBuilder::setAccountNumber(const std::string & accountNumber) {
+            _request.accountNumber = accountNumber;
+            return shared_from_this();
+        }
+
         std::shared_ptr<api::CosmosLikeTransactionBuilder> CosmosLikeTransactionBuilder::setMemo(const std::string & memo) {
             _request.memo = memo;
             return shared_from_this();

--- a/core/src/wallet/cosmos/transaction_builders/CosmosLikeTransactionBuilder.hpp
+++ b/core/src/wallet/cosmos/transaction_builders/CosmosLikeTransactionBuilder.hpp
@@ -49,6 +49,7 @@ namespace ledger {
         struct CosmosLikeTransactionBuildRequest {
             std::shared_ptr<BigInt> fee;
             std::shared_ptr<BigInt> gas;
+            std::string accountNumber;
             std::string memo;
             std::string sequence;
             std::vector<std::shared_ptr<api::CosmosLikeMessage>> messages;
@@ -70,6 +71,8 @@ namespace ledger {
             std::shared_ptr<api::CosmosLikeTransactionBuilder> setMemo(const std::string & memo) override;
 
             std::shared_ptr<api::CosmosLikeTransactionBuilder> setSequence(const std::string & sequence) override;
+
+            std::shared_ptr<api::CosmosLikeTransactionBuilder> setAccountNumber(const std::string & accountNumber) override;
 
             std::shared_ptr<api::CosmosLikeTransactionBuilder> addMessage(const std::shared_ptr<api::CosmosLikeMessage> & msg) override;
 

--- a/core/test/integration/synchronization/cosmos_synchronization.cpp
+++ b/core/test/integration/synchronization/cosmos_synchronization.cpp
@@ -339,11 +339,11 @@ TEST_F(CosmosLikeWalletSynchronization, MediumXpubSynchronization) {
             fmt::print("Ops: {}\n", ops.size());
             EXPECT_GT(ops.size(), 0);
 
-            const auto sequenceNumber = account->getSequence();
+            const auto sequenceNumber = account->getInfo().sequence;
             const int sequence = std::atoi(sequenceNumber.c_str());
             EXPECT_GE(sequence, 1226) << "Sequence was at 1226 on 2020-03-26";
 
-            const auto accountNumber = account->getAccountNumber();
+            const auto accountNumber = account->getInfo().accountNumber;
             EXPECT_EQ(accountNumber, "12850");
         }
     }


### PR DESCRIPTION
Various fixes are needed to reach a state where the transaction builder defaults to 

- having the correct AccountNumber and the correct Sequence number to sign
- Return the result of the post to the explorer
