### PR TITLE
End of Fig Cosmos API fixes

### DIFF
--- a/core/idl/wallet/cosmos/messages.djinni
+++ b/core/idl/wallet/cosmos/messages.djinni
@@ -164,6 +164,14 @@ CosmosLikeMessage = interface +c {
         # @return string a message type in string format
         const getRawMessageType(): string;
 
+        # Get type
+        # @return bool if the message was successfully executed on the chain
+        const getSuccess(): bool;
+
+        # Get type
+        # @return string the log of the message execution (useful when getSuccess() == false)
+        const getLog(): string;
+
         # Wrap the given CosmosLikeMsgSend into a CosmosLikeMessage
         # @param msg The message you need to wrap.
         # @return CosmosLikeMessage A wrapped message.

--- a/core/idl/wallet/cosmos/wallet.djinni
+++ b/core/idl/wallet/cosmos/wallet.djinni
@@ -30,7 +30,12 @@ CosmosLikeTransaction = interface +c {
         setDERSignature(signature: binary);
 
         # Serialize the transaction to be broadcast
-        serializeForBroadcast(): string;
+        # @param mode The supported broadcast modes include
+        #        "block"(return after tx commit), (https://docs.cosmos.network/master/basics/tx-lifecycle.html#commit)
+        #        "sync"(return afer CheckTx), (https://docs.cosmos.network/master/basics/tx-lifecycle.html#types-of-checks) and
+        #        "async"(return right away).
+        # @return string the json payload to broadcast on the network
+        serializeForBroadcast(mode: string): string;
 }
 
 #Class representing a Cosmos Operation

--- a/core/src/api/CosmosLikeMessage.hpp
+++ b/core/src/api/CosmosLikeMessage.hpp
@@ -50,6 +50,18 @@ public:
     virtual std::string getRawMessageType() const = 0;
 
     /**
+     * Get type
+     * @return bool if the message was successfully executed on the chain
+     */
+    virtual bool getSuccess() const = 0;
+
+    /**
+     * Get type
+     * @return string the log of the message execution (useful when getSuccess() == false)
+     */
+    virtual std::string getLog() const = 0;
+
+    /**
      * Wrap the given CosmosLikeMsgSend into a CosmosLikeMessage
      * @param msg The message you need to wrap.
      * @return CosmosLikeMessage A wrapped message.

--- a/core/src/api/CosmosLikeTransaction.hpp
+++ b/core/src/api/CosmosLikeTransaction.hpp
@@ -56,8 +56,15 @@ public:
 
     virtual void setDERSignature(const std::vector<uint8_t> & signature) = 0;
 
-    /** Serialize the transaction to be broadcast */
-    virtual std::string serializeForBroadcast() = 0;
+    /**
+     * Serialize the transaction to be broadcast
+     * @param mode The supported broadcast modes include
+     *        "block"(return after tx commit), (https://docs.cosmos.network/master/basics/tx-lifecycle.html#commit)
+     *        "sync"(return afer CheckTx), (https://docs.cosmos.network/master/basics/tx-lifecycle.html#types-of-checks) and
+     *        "async"(return right away).
+     * @return string the json payload to broadcast on the network
+     */
+    virtual std::string serializeForBroadcast(const std::string & mode) = 0;
 };
 
 } } }  // namespace ledger::core::api

--- a/core/src/cosmos/CosmosLikeAddress.cpp
+++ b/core/src/cosmos/CosmosLikeAddress.cpp
@@ -99,7 +99,11 @@ namespace ledger {
                                                                          const api::Currency &currency,
                                                                          const Option<std::string> &derivationPath) {
             auto& params = networks::getCosmosLikeNetworkParameters(currency.name);
-            auto type = address.find(cosmos::getBech32Params(api::CosmosBech32Type::ADDRESS_VAL).hrp) == std::string::npos ? api::CosmosBech32Type::ADDRESS : api::CosmosBech32Type::ADDRESS_VAL;
+            auto type =
+                address.find(cosmos::getBech32Params(api::CosmosBech32Type::ADDRESS_VAL).hrp) ==
+                        std::string::npos
+                    ? api::CosmosBech32Type::ADDRESS
+                    : api::CosmosBech32Type::ADDRESS_VAL;
             auto bech32 = std::make_shared<CosmosBech32>(type);
             auto decoded = bech32->decode(address);
             // Second supposed to be hash160 of pubKey

--- a/core/src/jni/jni/CosmosLikeMessage.cpp
+++ b/core/src/jni/jni/CosmosLikeMessage.cpp
@@ -55,6 +55,26 @@ CJNIEXPORT jstring JNICALL Java_co_ledger_core_CosmosLikeMessage_00024CppProxy_n
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
+CJNIEXPORT jboolean JNICALL Java_co_ledger_core_CosmosLikeMessage_00024CppProxy_native_1getSuccess(JNIEnv* jniEnv, jobject /*this*/, jlong nativeRef)
+{
+    try {
+        DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
+        const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::CosmosLikeMessage>(nativeRef);
+        auto r = ref->getSuccess();
+        return ::djinni::release(::djinni::Bool::fromCpp(jniEnv, r));
+    } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
+}
+
+CJNIEXPORT jstring JNICALL Java_co_ledger_core_CosmosLikeMessage_00024CppProxy_native_1getLog(JNIEnv* jniEnv, jobject /*this*/, jlong nativeRef)
+{
+    try {
+        DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
+        const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::CosmosLikeMessage>(nativeRef);
+        auto r = ref->getLog();
+        return ::djinni::release(::djinni::String::fromCpp(jniEnv, r));
+    } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
+}
+
 CJNIEXPORT jobject JNICALL Java_co_ledger_core_CosmosLikeMessage_wrapMsgSend(JNIEnv* jniEnv, jobject /*this*/, jobject j_msg)
 {
     try {

--- a/core/src/jni/jni/CosmosLikeTransaction.cpp
+++ b/core/src/jni/jni/CosmosLikeTransaction.cpp
@@ -120,12 +120,12 @@ CJNIEXPORT void JNICALL Java_co_ledger_core_CosmosLikeTransaction_00024CppProxy_
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, )
 }
 
-CJNIEXPORT jstring JNICALL Java_co_ledger_core_CosmosLikeTransaction_00024CppProxy_native_1serializeForBroadcast(JNIEnv* jniEnv, jobject /*this*/, jlong nativeRef)
+CJNIEXPORT jstring JNICALL Java_co_ledger_core_CosmosLikeTransaction_00024CppProxy_native_1serializeForBroadcast(JNIEnv* jniEnv, jobject /*this*/, jlong nativeRef, jstring j_mode)
 {
     try {
         DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
         const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::CosmosLikeTransaction>(nativeRef);
-        auto r = ref->serializeForBroadcast();
+        auto r = ref->serializeForBroadcast(::djinni::String::toCpp(jniEnv, j_mode));
         return ::djinni::release(::djinni::String::fromCpp(jniEnv, r));
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }

--- a/core/src/wallet/cosmos/CosmosLikeAccount.cpp
+++ b/core/src/wallet/cosmos/CosmosLikeAccount.cpp
@@ -595,7 +595,7 @@ namespace ledger {
                 }
 
                 void CosmosLikeAccount::broadcastTransaction(const std::shared_ptr<api::CosmosLikeTransaction> &transaction, const std::shared_ptr<api::StringCallback>& callback) {
-                        broadcastRawTransaction(transaction->serializeForBroadcast(), callback);
+                        broadcastRawTransaction(transaction->serializeForBroadcast("block"), callback);
                 }
 
                 std::shared_ptr<api::CosmosLikeTransactionBuilder> CosmosLikeAccount::buildTransaction() {

--- a/core/src/wallet/cosmos/CosmosLikeMessage.cpp
+++ b/core/src/wallet/cosmos/CosmosLikeMessage.cpp
@@ -199,6 +199,16 @@ api::CosmosLikeMsgType CosmosLikeMessage::getMessageType() const {
 
 std::string CosmosLikeMessage::getRawMessageType() const { return _msgData.type; }
 
+bool CosmosLikeMessage::getSuccess() const
+{
+    return _msgData.log.success;
+}
+
+std::string CosmosLikeMessage::getLog() const
+{
+    return _msgData.log.log;
+}
+
 // Note : this Json has not been sorted yet
 // This doesn't follow the spec
 // https://github.com/cosmos/ledger-cosmos-app/blob/master/docs/TXSPEC.md

--- a/core/src/wallet/cosmos/CosmosLikeMessage.hpp
+++ b/core/src/wallet/cosmos/CosmosLikeMessage.hpp
@@ -30,50 +30,46 @@
 
 #pragma once
 
-#include <rapidjson/document.h>
-
-#include <collections/DynamicObject.hpp>
-
-#include <wallet/cosmos/cosmos.hpp>
-#include <wallet/common/api_impl/OperationApi.h>
-
 #include <api/CosmosLikeAmount.hpp>
 #include <api/CosmosLikeContent.hpp>
-#include <api/CosmosLikeVoteOption.hpp>
-#include <api/CosmosLikeMsgSend.hpp>
-#include <api/CosmosLikeMsgDelegate.hpp>
-#include <api/CosmosLikeMsgUndelegate.hpp>
-#include <api/CosmosLikeMsgBeginRedelegate.hpp>
-#include <api/CosmosLikeMsgSubmitProposal.hpp>
-#include <api/CosmosLikeMsgVote.hpp>
-#include <api/CosmosLikeMsgDeposit.hpp>
-#include <api/CosmosLikeMsgWithdrawDelegationReward.hpp>
 #include <api/CosmosLikeMessage.hpp>
+#include <api/CosmosLikeMsgBeginRedelegate.hpp>
+#include <api/CosmosLikeMsgDelegate.hpp>
+#include <api/CosmosLikeMsgDeposit.hpp>
+#include <api/CosmosLikeMsgSend.hpp>
+#include <api/CosmosLikeMsgSubmitProposal.hpp>
 #include <api/CosmosLikeMsgType.hpp>
+#include <api/CosmosLikeMsgUndelegate.hpp>
+#include <api/CosmosLikeMsgVote.hpp>
+#include <api/CosmosLikeMsgWithdrawDelegationReward.hpp>
+#include <api/CosmosLikeVoteOption.hpp>
+#include <collections/DynamicObject.hpp>
+#include <rapidjson/document.h>
+#include <wallet/common/api_impl/OperationApi.h>
+#include <wallet/cosmos/cosmos.hpp>
 
 namespace ledger {
-	namespace core {
-		class CosmosLikeMessage : public api::CosmosLikeMessage {
-			friend api::CosmosLikeMessage;
+namespace core {
+class CosmosLikeMessage : public api::CosmosLikeMessage {
+    friend api::CosmosLikeMessage;
 
-		public:
+   public:
+    CosmosLikeMessage(const cosmos::Message &msgData);
+    CosmosLikeMessage(const std::shared_ptr<OperationApi> &baseOp);
 
-        	CosmosLikeMessage(const cosmos::Message& msgData);
-        	CosmosLikeMessage(const std::shared_ptr<OperationApi>& baseOp);
+    api::CosmosLikeMsgType getMessageType() const override;
+    std::string getRawMessageType() const override;
+    bool getSuccess() const override;
+    std::string getLog() const override;
 
-			virtual api::CosmosLikeMsgType getMessageType() const override;
-			virtual std::string getRawMessageType() const override;
+    rapidjson::Value toJson(rapidjson::Document::AllocatorType &allocator) const;
 
-			rapidjson::Value toJson(rapidjson::Document::AllocatorType& allocator) const;
+    void setRawData(const cosmos::Message &msgData);
+    const cosmos::Message &getRawData() const;
+    const std::string &getFromAddress() const;
 
-            void setRawData(const cosmos::Message &msgData);
-			const cosmos::Message& getRawData() const;
-            const std::string& getFromAddress() const;
-
-		private:
-
-			cosmos::Message _msgData;
-
-		};
-	}
-}
+   private:
+    cosmos::Message _msgData;
+};
+}  // namespace core
+}  // namespace ledger

--- a/core/src/wallet/cosmos/api_impl/CosmosLikeTransactionApi.cpp
+++ b/core/src/wallet/cosmos/api_impl/CosmosLikeTransactionApi.cpp
@@ -255,7 +255,7 @@ namespace ledger {
         // Builds the payload to broadcast the transaction
         // NOTE The produced payload is not a 1:1 mapping of this CosmosLikeTransactionApi because a "mode" is added to the json.
         // (cf.https://github.com/cosmos/cosmos-sdk/blob/2e42f9cb745aaa4c1a52ee730a969a5eaa938360/x/auth/client/rest/broadcast.go#L13-L16))
-        std::string CosmosLikeTransactionApi::serializeForBroadcast() {
+        std::string CosmosLikeTransactionApi::serializeForBroadcast(const std::string& mode) {
 
             using namespace cosmos::constants;
             Value vString(kStringType);
@@ -345,7 +345,7 @@ namespace ledger {
 
             // Set mode
             // TODO What mode do we want? (sync|async|block)
-            vString.SetString("block", static_cast<SizeType>(5), allocator);
+            vString.SetString(mode.c_str(), static_cast<SizeType>(mode.length()), allocator);
             document.AddMember(kMode, vString, allocator);
 
             StringBuffer buffer;

--- a/core/src/wallet/cosmos/api_impl/CosmosLikeTransactionApi.hpp
+++ b/core/src/wallet/cosmos/api_impl/CosmosLikeTransactionApi.hpp
@@ -79,7 +79,7 @@ namespace ledger {
             std::vector<uint8_t> getSigningPubKey() const override;
 
             std::string serializeForSignature() override;
-            std::string serializeForBroadcast() override;
+            std::string serializeForBroadcast(const std::string& mode) override;
 
             void setRawData(const cosmos::Transaction &txData);
             const cosmos::Transaction & getRawData() const;

--- a/core/src/wallet/cosmos/cosmos.hpp
+++ b/core/src/wallet/cosmos/cosmos.hpp
@@ -134,12 +134,6 @@ namespace ledger {
                             MsgFees,
                             MsgUnsupported>;
 
-                        struct Message {
-                                std::string uid;
-                                std::string type;
-                                MessageContent content;
-                        };
-
                         /**
                            Status of completion of a given message (success/failure and reason in case of failure),
                            MessageLog.messageIndex is the index of the message in the message list held by the transaction object.
@@ -149,6 +143,19 @@ namespace ledger {
                                 bool success;
                                 std::string log;
                         };
+
+                        /**
+                         * Structure containing message related information.
+                         * The message also contains a copy of the MessageLog structure
+                         * for easier bundling.
+                         */
+                        struct Message {
+                                std::string uid;
+                                std::string type;
+                                MessageLog log;
+                                MessageContent content;
+                        };
+
 
                         /**
                            Represents the fee object which is a combination of an amount of fee and the amount of gas that this fee holds.

--- a/core/src/wallet/cosmos/database/CosmosLikeTransactionDatabaseHelper.cpp
+++ b/core/src/wallet/cosmos/database/CosmosLikeTransactionDatabaseHelper.cpp
@@ -78,6 +78,9 @@ namespace ledger {
             msg.uid = row.get<std::string>(COL_UID);
             auto msgType = row.get<std::string>(COL_MSGTYPE);
             msg.type = msgType;
+            msg.log.success = (row.get<int32_t>(COL_SUCCESS) == 1);
+            msg.log.log = row.get<std::string>(COL_LOG);
+            msg.log.messageIndex = row.get<int32_t>(COL_MSGINDEX);
             switch (cosmos::stringToMsgType(msgType.c_str())) {
                 case api::CosmosLikeMsgType::MSGSEND:
                     {

--- a/core/src/wallet/cosmos/explorers/RpcsParsers.hpp
+++ b/core/src/wallet/cosmos/explorers/RpcsParsers.hpp
@@ -397,8 +397,9 @@ namespace ledger {
             }
 
             template <typename T>
-            void parseMessage(const T& messageNode, cosmos::Message& out) {
+            void parseMessage(const T& messageNode, cosmos::Message& out, const cosmos::MessageLog& associated_log) {
                 out.type = messageNode[kType].GetString();
+                out.log = associated_log;
                 const auto& contentNode = messageNode[kValue].GetObject();
                 COSMOS_PARSE_MSG_CONTENT(MsgSend)
                 COSMOS_PARSE_MSG_CONTENT(MsgDelegate)
@@ -473,7 +474,7 @@ namespace ledger {
                     transaction.messages.assign((std::size_t) msgArray.Capacity(), cosmos::Message());
                     auto index = 0;
                     for (const auto &mNode : msgArray) {
-                        parseMessage(mNode, transaction.messages[index]);
+                        parseMessage(mNode, transaction.messages[index], transaction.logs[index]);
                         index++;
                     }
                 }

--- a/core/src/wallet/pool/database/CurrenciesDatabaseHelper.cpp
+++ b/core/src/wallet/pool/database/CurrenciesDatabaseHelper.cpp
@@ -85,6 +85,24 @@ bool ledger::core::CurrenciesDatabaseHelper::insertCurrency(soci::session &sql,
                 use(BIPs);
                 break;
             }
+            case api::WalletType::COSMOS: {
+                auto &params = currency.cosmosLikeNetworkParameters.value();
+
+                std::stringstream additionalCIPs;
+                std::string separator(",");
+                strings::join(params.AdditionalCIPs, additionalCIPs, separator);
+                auto CIPs = additionalCIPs.str();
+                auto hexXPUBVersion = hex::toString(params.XPUBVersion);
+                auto hexPubKeyPrefix = hex::toString(params.PubKeyPrefix);
+                auto hexAddressPrefix = hex::toString(params.AddressPrefix);
+                sql << "INSERT INTO cosmos_currencies VALUES(:name, :identifier, :xpub, "
+                       ":pubkey_prefix, :address_prefix, :message_prefix, :chain_id, "
+                       ":additionalCIPs)",
+                    use(currency.name), use(params.Identifier), use(hexXPUBVersion),
+                    use(hexPubKeyPrefix), use(hexAddressPrefix), use(params.MessagePrefix),
+                    use(params.ChainId), use(CIPs);
+                break;
+            }
             case api::WalletType::ETHEREUM: {
                 auto &params = currency.ethereumLikeNetworkParameters.value();
 

--- a/core/test/cosmos/transactions_test.cpp
+++ b/core/test/cosmos/transactions_test.cpp
@@ -77,8 +77,8 @@ TEST(CosmosTransactionTest, BuildSignedSendTxForBroadcast) {
     EXPECT_EQ(sendMessage.amount.front().amount, "1000000");
     EXPECT_EQ(sendMessage.amount.front().denom, "uatom");
 
-    const std::string expected = "{\"mode\":\"block\",\"tx\":" + strTx + "}";
-    EXPECT_EQ(tx->serializeForBroadcast(), expected);
+    const std::string expected = "{\"mode\":\"async\",\"tx\":" + strTx + "}";
+    EXPECT_EQ(tx->serializeForBroadcast("async"), expected);
 }
 
 TEST(CosmosTransactionTest, BuildDelegateTxForBroadcast) {
@@ -103,8 +103,8 @@ TEST(CosmosTransactionTest, BuildDelegateTxForBroadcast) {
     EXPECT_EQ(delegateMessage.amount.amount, "1000000");
     EXPECT_EQ(delegateMessage.amount.denom, "uatom");
 
-    const std::string expected = "{\"mode\":\"block\",\"tx\":" + strTx + "}";
-    EXPECT_EQ(tx->serializeForBroadcast(), expected);
+    const std::string expected = "{\"mode\":\"async\",\"tx\":" + strTx + "}";
+    EXPECT_EQ(tx->serializeForBroadcast("async"), expected);
 }
 
 TEST(CosmosTransactionTest, BuildUndelegateTxForBroadcast) {
@@ -130,7 +130,7 @@ TEST(CosmosTransactionTest, BuildUndelegateTxForBroadcast) {
     EXPECT_EQ(undelegateMessage.amount.denom, "uatom");
 
     const std::string expected = "{\"mode\":\"block\",\"tx\":" + strTx + "}";
-    EXPECT_EQ(tx->serializeForBroadcast(), expected);
+    EXPECT_EQ(tx->serializeForBroadcast("block"), expected);
 }
 
 TEST(CosmosTransactionTest, BuildBeginRedelegateTxForBroadcast) {
@@ -157,8 +157,8 @@ TEST(CosmosTransactionTest, BuildBeginRedelegateTxForBroadcast) {
     EXPECT_EQ(redelegateMessage.amount.amount, "1000000");
     EXPECT_EQ(redelegateMessage.amount.denom, "uatom");
 
-    const std::string expected = "{\"mode\":\"block\",\"tx\":" + strTx + "}";
-    EXPECT_EQ(tx->serializeForBroadcast(), expected);
+    const std::string expected = "{\"mode\":\"sync\",\"tx\":" + strTx + "}";
+    EXPECT_EQ(tx->serializeForBroadcast("sync"), expected);
 }
 
 TEST(CosmosTransactionTest, BuildSubmitProposalTxForBroadcast) {
@@ -189,7 +189,7 @@ TEST(CosmosTransactionTest, BuildSubmitProposalTxForBroadcast) {
     EXPECT_EQ(submitProposalMessage.initialDeposit.front().denom, "uatom");
 
     const std::string expected = "{\"mode\":\"block\",\"tx\":" + strTx + "}";
-    EXPECT_EQ(tx->serializeForBroadcast(), expected);
+    EXPECT_EQ(tx->serializeForBroadcast("block"), expected);
 }
 
 TEST(CosmosTransactionTest, BuildVoteTxForBroadcast) {
@@ -213,8 +213,8 @@ TEST(CosmosTransactionTest, BuildVoteTxForBroadcast) {
     EXPECT_EQ(voteMessage.proposalId, "123");
     EXPECT_EQ(voteMessage.voter, "cosmos102hty0jv2s29lyc4u0tv97z9v298e24t3vwtpl");
 
-    const std::string expected = "{\"mode\":\"block\",\"tx\":" + strTx + "}";
-    EXPECT_EQ(tx->serializeForBroadcast(), expected);
+    const std::string expected = "{\"mode\":\"sync\",\"tx\":" + strTx + "}";
+    EXPECT_EQ(tx->serializeForBroadcast("sync"), expected);
 }
 
 TEST(CosmosTransactionTest, BuildDepositTxForBroadcast) {
@@ -240,8 +240,8 @@ TEST(CosmosTransactionTest, BuildDepositTxForBroadcast) {
     EXPECT_EQ(depositMessage.amount.front().amount, "1000000");
     EXPECT_EQ(depositMessage.amount.front().denom, "uatom");
 
-    const std::string expected = "{\"mode\":\"block\",\"tx\":" + strTx + "}";
-    EXPECT_EQ(tx->serializeForBroadcast(), expected);
+    const std::string expected = "{\"mode\":\"sync\",\"tx\":" + strTx + "}";
+    EXPECT_EQ(tx->serializeForBroadcast("sync"), expected);
 }
 
 TEST(CosmosTransactionTest, BuildWithdrawDelegationRewardTxForBroadcast) {
@@ -264,7 +264,7 @@ TEST(CosmosTransactionTest, BuildWithdrawDelegationRewardTxForBroadcast) {
     EXPECT_EQ(withdrawMessage.validatorAddress, "cosmosvaloper1grgelyng2v6v3t8z87wu3sxgt9m5s03xfytvz7");
 
     const std::string expected = "{\"mode\":\"block\",\"tx\":" + strTx + "}";
-    EXPECT_EQ(tx->serializeForBroadcast(), expected);
+    EXPECT_EQ(tx->serializeForBroadcast("block"), expected);
 }
 
 
@@ -297,8 +297,8 @@ TEST(CosmosTransactionTest, BuildMultiSendTxForBroadcast) {
     EXPECT_EQ(multiSendMessage.outputs[0].coins[0].amount, "10");
     EXPECT_EQ(multiSendMessage.outputs[0].coins[0].denom, "atom");
 
-    const std::string expected = "{\"mode\":\"block\",\"tx\":" + strTx + "}";
-    EXPECT_EQ(tx->serializeForBroadcast(), expected);
+    const std::string expected = "{\"mode\":\"async\",\"tx\":" + strTx + "}";
+    EXPECT_EQ(tx->serializeForBroadcast("async"), expected);
 }
 
 TEST(CosmosTransactionTest, BuildCreateValidatorTxForBroadcast) {
@@ -341,7 +341,7 @@ TEST(CosmosTransactionTest, BuildCreateValidatorTxForBroadcast) {
     EXPECT_EQ(createValidatorMessage.value.denom, "uatom");
 
     const std::string expected = "{\"mode\":\"block\",\"tx\":" + strTx + "}";
-    EXPECT_EQ(tx->serializeForBroadcast(), expected);
+    EXPECT_EQ(tx->serializeForBroadcast("block"), expected);
 }
 
 TEST(CosmosTransactionTest, BuildEditValidatorTxForBroadcast) {
@@ -380,7 +380,7 @@ TEST(CosmosTransactionTest, BuildEditValidatorTxForBroadcast) {
     EXPECT_EQ(editValidatorMessage.minSelfDelegation.value(), "800");
 
     const std::string expected = "{\"mode\":\"block\",\"tx\":" + strTx + "}";
-    EXPECT_EQ(tx->serializeForBroadcast(), expected);
+    EXPECT_EQ(tx->serializeForBroadcast("block"), expected);
 }
 
 TEST(CosmosTransactionTest, BuildSetWithdrawAddressTxForBroadcast) {
@@ -403,8 +403,8 @@ TEST(CosmosTransactionTest, BuildSetWithdrawAddressTxForBroadcast) {
     EXPECT_EQ(setWithdrawAddressMessage.delegatorAddress, "cosmos1dafe");
     EXPECT_EQ(setWithdrawAddressMessage.withdrawAddress, "cosmos1erfdsa");
 
-    const std::string expected = "{\"mode\":\"block\",\"tx\":" + strTx + "}";
-    EXPECT_EQ(tx->serializeForBroadcast(), expected);
+    const std::string expected = "{\"mode\":\"sync\",\"tx\":" + strTx + "}";
+    EXPECT_EQ(tx->serializeForBroadcast("sync"), expected);
 }
 
 TEST(CosmosTransactionTest, BuildWithdrawDelegatorRewardsTxForBroadcast) {
@@ -427,8 +427,8 @@ TEST(CosmosTransactionTest, BuildWithdrawDelegatorRewardsTxForBroadcast) {
     EXPECT_EQ(withdrawDorRewardMessage.delegatorAddress, "cosmos1targ");
     EXPECT_EQ(withdrawDorRewardMessage.validatorAddress, "cosmosvaloperwdfae");
 
-    const std::string expected = "{\"mode\":\"block\",\"tx\":" + strTx + "}";
-    EXPECT_EQ(tx->serializeForBroadcast(), expected);
+    const std::string expected = "{\"mode\":\"async\",\"tx\":" + strTx + "}";
+    EXPECT_EQ(tx->serializeForBroadcast("async"), expected);
 }
 
 TEST(CosmosTransactionTest, BuildWithdrawValidatorCommissionTxForBroadcast) {
@@ -448,8 +448,8 @@ TEST(CosmosTransactionTest, BuildWithdrawValidatorCommissionTxForBroadcast) {
     EXPECT_EQ(tx->getGas()->toLong(), 200020L);
     EXPECT_EQ(withdrawVorCommissionMessage.validatorAddress, "cosmosvaloper1234567890");
 
-    const std::string expected = "{\"mode\":\"block\",\"tx\":" + strTx + "}";
-    EXPECT_EQ(tx->serializeForBroadcast(), expected);
+    const std::string expected = "{\"mode\":\"async\",\"tx\":" + strTx + "}";
+    EXPECT_EQ(tx->serializeForBroadcast("async"), expected);
 }
 
 TEST(CosmosTransactionTest, BuildUnjailTxForBroadcast) {
@@ -470,7 +470,7 @@ TEST(CosmosTransactionTest, BuildUnjailTxForBroadcast) {
     EXPECT_EQ(unjailMessage.validatorAddress, "cosmosvaloper1dalton");
 
     const std::string expected = "{\"mode\":\"block\",\"tx\":" + strTx + "}";
-    EXPECT_EQ(tx->serializeForBroadcast(), expected);
+    EXPECT_EQ(tx->serializeForBroadcast("block"), expected);
 }
 
 TEST(CosmosTransactionTest, BuildSendTxForSignature) {

--- a/core/test/integration/synchronization/cosmos_synchronization.cpp
+++ b/core/test/integration/synchronization/cosmos_synchronization.cpp
@@ -202,6 +202,7 @@ TEST_F(CosmosLikeWalletSynchronization, GetWithdrawDelegationRewardWithExplorer)
                 FAIL() << cosmos::constants::kMsgWithdrawDelegationReward << " message not found in tx";
             }
             EXPECT_TRUE(tx->logs[withdraw_msg_index].success);
+            EXPECT_TRUE(tx->messages[withdraw_msg_index].log.success);
             EXPECT_EQ(tx->messages[withdraw_msg_index].type, cosmos::constants::kMsgWithdrawDelegationReward);
             const cosmos::MsgWithdrawDelegationReward& msg = boost::get<cosmos::MsgWithdrawDelegationReward>(tx->messages[0].content);
             EXPECT_EQ(msg.delegatorAddress, DEFAULT_ADDRESS);
@@ -226,8 +227,12 @@ TEST_F(CosmosLikeWalletSynchronization, GetErrorTransaction) {
     ASSERT_EQ(tx->hash, tx_hash);
     EXPECT_EQ(tx->block->height, 768780);
     EXPECT_EQ(tx->logs.size(), 2);
+    // Logs are stored twice now, but only in serialized types
+    // DB will only ever store logs in cosmos_messages table anyway
     EXPECT_FALSE(tx->logs[0].success);
     EXPECT_EQ(tx->logs[0].log, "{\"codespace\":\"sdk\",\"code\":10,\"message\":\"insufficient account funds; 2412592uatom < 2417501uatom\"}");
+    EXPECT_FALSE(tx->messages[0].log.success);
+    EXPECT_EQ(tx->messages[0].log.log, R"esc({"codespace":"sdk","code":10,"message":"insufficient account funds; 2412592uatom < 2417501uatom"})esc");
     EXPECT_EQ(tx->messages[0].type, cosmos::constants::kMsgDelegate);
     const cosmos::MsgDelegate& msg = boost::get<cosmos::MsgDelegate>(tx->messages[0].content);
     EXPECT_EQ(msg.delegatorAddress, delegator);
@@ -252,6 +257,7 @@ TEST_F(CosmosLikeWalletSynchronization, GetSendWithExplorer) {
     EXPECT_EQ(tx->block->height, 453223);
     EXPECT_EQ(tx->logs.size(), 2);
     EXPECT_TRUE(tx->logs[0].success);
+    EXPECT_TRUE(tx->messages[0].log.success);
     EXPECT_EQ(tx->messages[0].type, cosmos::constants::kMsgSend);
     const cosmos::MsgSend& msg = boost::get<cosmos::MsgSend>(tx->messages[0].content);
     EXPECT_EQ(msg.fromAddress, sender);
@@ -286,6 +292,7 @@ TEST_F(CosmosLikeWalletSynchronization, GetDelegateWithExplorer) {
             EXPECT_EQ(tx->block->height, 660081);
             EXPECT_EQ(tx->logs.size(), 2);
             EXPECT_TRUE(tx->logs[0].success);
+            EXPECT_TRUE(tx->messages[0].log.success);
             EXPECT_EQ(tx->messages[0].type, cosmos::constants::kMsgDelegate);
             const cosmos::MsgDelegate& msg = boost::get<cosmos::MsgDelegate>(tx->messages[0].content);
             EXPECT_EQ(msg.delegatorAddress, delegator);


### PR DESCRIPTION
These changes are meant to ease live integration later.

----

# Add MessageLog information inside the cosmos::Message struct

Live almost exclusively operates on cosmos::Message, so storing the log for the
message outside of the structure makes little sense.

This also allows to query the success and the log of a message directly once
inflated from an operation on the live side, this will help a lot.

# Insert Cosmos currencies in the cosmos_currencies table

This error was only caught by a compiler warning. The exact extent of this error
is unknown.

# Expose broadcast mode to ledgerlive (block, sync, async)

Let libcore clients choose the way they want the broadcast to happen
down the line.