### PR TITLE
Give an accessor to WithdrawAddress

### DIFF
--- a/core/idl/wallet/cosmos/wallet.djinni
+++ b/core/idl/wallet/cosmos/wallet.djinni
@@ -163,6 +163,10 @@ CosmosLikeAccount = interface +c {
         # Get the account number
         # String like "15"
         getAccountNumber(callback: Callback<string>);
+
+        # Get the rewards withdrawal address
+        # String Bech32 encoded string
+        getWithdrawAddress(callback: Callback<string>);
 }
 
 #Class representing a Cosmos delegation

--- a/core/src/api/CosmosLikeAccount.hpp
+++ b/core/src/api/CosmosLikeAccount.hpp
@@ -91,6 +91,12 @@ public:
      * String like "15"
      */
     virtual void getAccountNumber(const std::shared_ptr<StringCallback> & callback) = 0;
+
+    /**
+     * Get the rewards withdrawal address
+     * String Bech32 encoded string
+     */
+    virtual void getWithdrawAddress(const std::shared_ptr<StringCallback> & callback) = 0;
 };
 
 } } }  // namespace ledger::core::api

--- a/core/src/database/migrations.cpp
+++ b/core/src/database/migrations.cpp
@@ -872,6 +872,7 @@ namespace ledger {
                 "account_number VARCHAR(255),"
                 "sequence VARCHAR(255),"
                 "balances VARCHAR(255),"
+                "withdraw_address VARCHAR(255),"
                 "last_update TEXT"
                 ")";
 

--- a/core/src/jni/jni/CosmosLikeAccount.cpp
+++ b/core/src/jni/jni/CosmosLikeAccount.cpp
@@ -199,4 +199,13 @@ CJNIEXPORT void JNICALL Java_co_ledger_core_CosmosLikeAccount_00024CppProxy_nati
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, )
 }
 
+CJNIEXPORT void JNICALL Java_co_ledger_core_CosmosLikeAccount_00024CppProxy_native_1getWithdrawAddress(JNIEnv* jniEnv, jobject /*this*/, jlong nativeRef, jobject j_callback)
+{
+    try {
+        DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
+        const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::CosmosLikeAccount>(nativeRef);
+        ref->getWithdrawAddress(::djinni_generated::StringCallback::toCpp(jniEnv, j_callback));
+    } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, )
+}
+
 }  // namespace djinni_generated

--- a/core/src/wallet/cosmos/CosmosLikeAccount.cpp
+++ b/core/src/wallet/cosmos/CosmosLikeAccount.cpp
@@ -673,6 +673,15 @@ namespace ledger {
                     return Future<std::string>::successful(_accountData->accountNumber).callback(getContext(), callback);
                 }
 
+                void CosmosLikeAccount::getWithdrawAddress(const std::shared_ptr<api::StringCallback>& callback)
+                {
+                    if (!_accountData) {
+                        throw make_exception(
+                            api::ErrorCode::ILLEGAL_STATE, "account must be synchronized first");
+                    }
+                    return Future<std::string>::successful(_accountData->withdrawAddress).callback(getContext(), callback);
+                }
+
                 cosmos::Account CosmosLikeAccount::getInfo() const {
                         return cosmos::Account(*_accountData);
                 }

--- a/core/src/wallet/cosmos/CosmosLikeAccount.hpp
+++ b/core/src/wallet/cosmos/CosmosLikeAccount.hpp
@@ -131,6 +131,7 @@ namespace ledger {
                                 // Account related data
                                 void getSequence(const std::shared_ptr<api::StringCallback>& callback) override;
                                 void getAccountNumber(const std::shared_ptr<api::StringCallback>& callback) override;
+                                void getWithdrawAddress(const std::shared_ptr<api::StringCallback>& callback) override;
                                 cosmos::Account getInfo() const;
 
                                 // Balances

--- a/core/src/wallet/cosmos/CosmosLikeConstants.hpp
+++ b/core/src/wallet/cosmos/CosmosLikeConstants.hpp
@@ -46,6 +46,7 @@ namespace ledger {
                                 constexpr const char kGaiaTransfersEndpoint[] = "/bank/accounts/{}/transfers";
                                 constexpr const char kGaiaDistInfoEndpoint[] = "/distribution/validators/{}";
                                 constexpr const char kGaiaSignInfoEndpoint[] = "/slashing/validators/{}/signing_info";
+                                constexpr const char kGaiaWithdrawAddressEndpoint[] = "/distribution/delegators/{}/withdraw_address";
 
                                 // use raw char array here to be compliant with rapidjson
                                 constexpr const char kMsgBeginRedelegate[] = "cosmos-sdk/MsgBeginRedelegate";

--- a/core/src/wallet/cosmos/cosmos.hpp
+++ b/core/src/wallet/cosmos/cosmos.hpp
@@ -186,6 +186,7 @@ namespace ledger {
                                 std::vector<Coin> balances;
                                 std::string accountNumber;
                                 std::string sequence;
+                                std::string withdrawAddress;
                                 std::chrono::system_clock::time_point lastUpdate;
                         };
 

--- a/core/src/wallet/cosmos/explorers/GaiaCosmosLikeBlockchainExplorer.cpp
+++ b/core/src/wallet/cosmos/explorers/GaiaCosmosLikeBlockchainExplorer.cpp
@@ -107,21 +107,47 @@ namespace ledger {
                 });
         }
 
-        FuturePtr<ledger::core::cosmos::Account>
-        GaiaCosmosLikeBlockchainExplorer::getAccount(const std::string &account) const {
+        FuturePtr<ledger::core::cosmos::Account> GaiaCosmosLikeBlockchainExplorer::getAccount(
+            const std::string &account) const
+        {
+            // NOTE : those futures do not need to be chained
+            // as only "account" is needed as argument to the futures.
+            // First call gets the /auth/accounts information (general info)
+            // Second call gets the "withdrawAddress" (where rewards go)
+            const bool parseJsonNumbersAsStrings = true;
             return _http->GET(fmt::format("/auth/accounts/{}", account), ACCEPT_HEADER)
-                .json(true)
-                .mapPtr<cosmos::Account>(getContext(), [] (const HttpRequest::JsonResult& response) {
-                    auto result = std::make_shared<cosmos::Account>();
-                    const auto& document = std::get<1>(response)->GetObject();
-                    if (!document.HasMember("result")) {
-                        throw make_exception(
-                            api::ErrorCode::API_ERROR,
-                            "The API response from explorer is missing the \"result\" key");
-                    }
-                    rpcs_parsers::parseAccount(document["result"], *result);
-                    return result;
-                });
+                .json(parseJsonNumbersAsStrings)
+                .template flatMap<cosmos::Account>(
+                    getContext(),
+                    [](const HttpRequest::JsonResult &response) {
+                        auto result = cosmos::Account();
+                        const auto &document = std::get<1>(response)->GetObject();
+                        if (!document.HasMember("result")) {
+                            throw make_exception(
+                                api::ErrorCode::API_ERROR,
+                                "The API response from explorer is missing the \"result\" key");
+                        }
+                        rpcs_parsers::parseAccount(document["result"], result);
+                        return Future<cosmos::Account>::successful(result);
+                    })
+                .template flatMapPtr<cosmos::Account>(
+                    getContext(),
+                    [this, parseJsonNumbersAsStrings, account](
+                        const cosmos::Account &inputAcc)
+                        -> FuturePtr<cosmos::Account> {
+                        auto retval = cosmos::Account(inputAcc);
+                        return _http->GET(fmt::format(kGaiaWithdrawAddressEndpoint, account))
+                            .json(parseJsonNumbersAsStrings)
+                            .template flatMapPtr<cosmos::Account>(
+                                getContext(),
+                                [retval](const HttpRequest::JsonResult &response) mutable
+                                -> FuturePtr<cosmos::Account> {
+                                    const auto &document = std::get<1>(response)->GetObject();
+                                    const auto withdrawAddress = document["result"].GetString();
+                                    retval.withdrawAddress = withdrawAddress;
+                                    return FuturePtr<cosmos::Account>::successful(std::make_shared<cosmos::Account>(retval));
+                                });
+                    });
         }
 
         FuturePtr<cosmos::Block> GaiaCosmosLikeBlockchainExplorer::getCurrentBlock() {

--- a/core/src/wallet/cosmos/explorers/GaiaCosmosLikeBlockchainExplorer.cpp
+++ b/core/src/wallet/cosmos/explorers/GaiaCosmosLikeBlockchainExplorer.cpp
@@ -335,7 +335,7 @@ namespace ledger {
             std::vector<FuturePtr<cosmos::TransactionsBulk>> address_transactions;
             std::transform(addresses.begin(), addresses.end(), std::back_inserter(address_transactions),
                            [&] (const auto& address) {
-                               return getTransactionsForAddress(address, fromBlockHeight);
+                               return this->getTransactionsForAddress(address, fromBlockHeight);
                            });
             return async::sequence(getContext(), address_transactions)
                 .flatMapPtr<cosmos::TransactionsBulk>(getContext(), [](const auto& vector_of_bulks) {

--- a/core/test/integration/synchronization/cosmos_synchronization.cpp
+++ b/core/test/integration/synchronization/cosmos_synchronization.cpp
@@ -137,9 +137,10 @@ public:
 TEST_F(CosmosLikeWalletSynchronization, GetAccountWithExplorer) {
 
     auto account = ::wait(explorer->getAccount(DEFAULT_ADDRESS));
-    ASSERT_EQ(account->address, DEFAULT_ADDRESS);
-    ASSERT_EQ(account->accountNumber, "12850");
-
+    EXPECT_EQ(account->address, DEFAULT_ADDRESS);
+    EXPECT_EQ(account->accountNumber, "12850");
+    EXPECT_EQ(account->withdrawAddress, DEFAULT_ADDRESS)
+        << "Withdraw address has not been modified on this address";
 }
 
 
@@ -387,7 +388,7 @@ TEST_F(CosmosLikeWalletSynchronization, MediumXpubSynchronization) {
             EXPECT_GE(sequence, 1226) << "Sequence was at 1226 on 2020-03-26";
 
             const auto accountNumber = account->getInfo().accountNumber;
-            EXPECT_EQ(accountNumber, "12850");
+            EXPECT_EQ(accountNumber, "12850") << "Account number is a network constant for a given address";
         }
     }
 }


### PR DESCRIPTION
This allows endusers to check the withdrawAddress of the account (so a warning
can be emitted if the withdraw address is different than the account address)


Note that there is no feature here to easily expose the construction of a
MsgSetWithdrawAddress to send on the network : if a user has a different
withdrawAddress than their account address, they changed it on another platform,
and need to go back there to change it again.

----

#